### PR TITLE
Add GitHub Actions CI workflow and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync
+      - run: uv run python manage.py test

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
   <sub>Image generated with <a href="https://gemini.google/overview/image-generation/">Nano Banana</a> from the cover of <a href="https://en.wikipedia.org/wiki/Ragtime_(novel)">E.L. Doctorow's novel "Ragtime"</a></sub>
 </div>
 
+<br>
+
+<div align="center">
+
+[![CI](https://github.com/rafacm/ragtime/actions/workflows/ci.yml/badge.svg)](https://github.com/rafacm/ragtime/actions/workflows/ci.yml)
+[![Python 3.13](https://img.shields.io/badge/python-3.13-blue)](https://www.python.org/)
+[![Django 5.2](https://img.shields.io/badge/django-5.2-green)](https://www.djangoproject.com/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen)](LICENSE)
+
+</div>
+
 ## What is RAGtime?
 
 RAGtime is a Django application for ingesting jazz-related podcast episodes. It extracts metadata, transcribes audio, identifies jazz entities, and powers **Scott** — a jazz-focused AI agent that answers questions strictly from ingested episode content, with references to specific episodes and timestamps.
@@ -107,6 +118,7 @@ Set the following environment variables (or use a `.env` file):
 | 2026-03-09 | Step 2: Dedup — Duplicate episode detection via unique URL constraint at database level | [plan](doc/plans/step-02-dedup.md), [feature](doc/features/step-02-dedup.md), [session](doc/sessions/2026-03-09-step-02-dedup.md) |
 | 2026-03-09 | Step 3: Scrape — LLM-based metadata extraction with Django Q2 async tasks, provider abstraction, and needs_review workflow | [plan](doc/plans/step-03-scrape.md), [feature](doc/features/step-03-scrape.md), [session](doc/sessions/2026-03-09-step-03-scrape.md) |
 | 2026-03-09 | Steps 4 & 5: Download & Resize — Audio download with streaming, ffmpeg downsampling for Whisper API limit, error tracking | [plan](doc/plans/step-04-05-download-resize.md), [feature](doc/features/step-04-05-download-resize.md), [session](doc/sessions/2026-03-09-step-04-05-download-resize.md) |
+| 2026-03-10 | CI: GitHub Actions — Automated test suite on PRs and pushes to main, README badges for build status, Python, Django, license | [feature](doc/features/ci-github-actions.md), [session](doc/sessions/2026-03-10-ci-github-actions.md) |
 
 ## Built with AI
 

--- a/doc/features/ci-github-actions.md
+++ b/doc/features/ci-github-actions.md
@@ -1,0 +1,40 @@
+# CI: GitHub Actions Workflow + README Badges
+
+## Problem
+
+The project had no automated testing. PRs and pushes to `main` could introduce regressions without anyone noticing until manual testing. The README also lacked quick-glance project metadata (build status, Python/Django versions, license).
+
+## Changes
+
+- **GitHub Actions workflow** (`.github/workflows/ci.yml`): Runs the full Django test suite on every push to `main` and on every pull request targeting `main`. Uses `astral-sh/setup-uv@v6` to install dependencies via `uv sync`, matching the project's package management convention. Python version is resolved automatically from `pyproject.toml`.
+
+- **README badges**: Added a centered badge row below the hero image with four shields:
+  - **CI** — live build status from the GitHub Actions workflow
+  - **Python 3.13** — language version from `pyproject.toml`
+  - **Django 5.2** — framework version from dependencies
+  - **License: MIT** — links to the LICENSE file
+
+## Key Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Runner | `ubuntu-latest` | Standard GitHub-hosted runner, sufficient for Django tests |
+| uv action | `astral-sh/setup-uv@v6` | Official uv setup action; project uses uv exclusively |
+| Triggers | `push: main`, `pull_request: main` | Catch regressions before merge and after |
+
+## Verification
+
+```bash
+# Run tests locally
+uv run python manage.py test
+
+# Push branch and open PR → verify CI workflow triggers and passes
+# Check README renders badges correctly on GitHub
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | New — GitHub Actions workflow running `uv sync` + `manage.py test` |
+| `README.md` | Added badge row (CI, Python, Django, License) below hero image; added Features & Fixes entry |

--- a/doc/sessions/2026-03-10-ci-github-actions.md
+++ b/doc/sessions/2026-03-10-ci-github-actions.md
@@ -1,0 +1,60 @@
+# Session: CI — GitHub Actions Workflow + README Badges
+
+**Date:** 2026-03-10
+
+## Summary
+
+Added a GitHub Actions CI workflow to run the Django test suite on every PR and push to `main`, plus README badges for build status, Python version, Django version, and license.
+
+## Conversation
+
+### User
+Let's implement a GitHub action to run the tests for every PR and for changes to the main branch. Additionally add Python, Django, License and GitHub CI build status badges to the README.md file.
+
+### Assistant
+Explored the codebase: project structure, test setup (`python manage.py test`, 40 tests in `episodes/tests.py`), `pyproject.toml` (Python 3.13, Django 5.2, uv), no existing CI, MIT license, no badges in README.
+
+Entered plan mode and wrote the implementation plan.
+
+### Plan
+
+1. Create `.github/workflows/ci.yml` — triggers on push to `main` and PRs targeting `main`, uses `astral-sh/setup-uv@v6` for dependency installation, runs `uv run python manage.py test`.
+2. Add a centered badge row to `README.md` below the hero image with four shields: CI status, Python 3.13, Django 5.2, License MIT.
+
+### User
+Approved the plan.
+
+### Assistant
+Created `.github/workflows/ci.yml` with the workflow configuration. Added badge block to `README.md` between the hero image and the "What is RAGtime?" heading. Ran tests locally — all 40 passed.
+
+### User
+Document this as a feature as per the AGENTS.md instructions.
+
+### Assistant
+Created `doc/features/ci-github-actions.md` with Problem, Changes, Key Parameters, Verification, and Files Modified sections. Added a row to the Features & Fixes table in `README.md`.
+
+### User
+Commit changes and create a PR.
+
+### Assistant
+Created branch `ci/github-actions-workflow`, committed all changes, pushed, and opened PR #4.
+
+### User
+The session file is missing. Please generate it, amend the commit and force push.
+
+### Assistant
+Created `doc/sessions/2026-03-10-ci-github-actions.md`, updated the README Features & Fixes entry to include the session link, amended the commit, and force pushed.
+
+### User
+(Shared screenshot showing badges too close to the attribution text)
+
+We need to add space here.
+
+### Assistant
+Added a `<br>` between the attribution `</div>` and the badges `<div>` in `README.md` for vertical spacing.
+
+### User
+Update the session transcript file to include the full session, amend the commit with all the changes and force push it.
+
+### Assistant
+Updated session transcript with the full conversation, amended the commit, and force pushed.


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/ci.yml`) to run the Django test suite on every PR and push to `main`
- Add README badges for CI build status, Python 3.13, Django 5.2, and MIT license
- Add feature documentation in `doc/features/ci-github-actions.md`

## Test plan
- [x] CI workflow triggers and passes on this PR
- [x] Badges render correctly in README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)