### PR TITLE
Enable verbose test output in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - run: uv sync
-      - run: uv run python manage.py test
+      - run: uv run python manage.py test --verbosity 2


### PR DESCRIPTION
## Summary
- Add `--verbosity 2` to the Django test command in the CI workflow so each test name and result is printed in the GitHub Actions log

## Test plan
- [ ] Verify the CI workflow runs successfully and shows individual test names in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)