### PR TITLE
Add RAGTIME_SUMMARIZATION_* config to README, add config docs rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Feature documentation lives in `doc/features/`, one Markdown file per feature or
 
 Keep prose concise. Prefer tables and lists over long paragraphs. Use code blocks for CLI commands and signal-flow diagrams.
 
+Whenever a `RAGTIME_*` environment variable is added, changed, or removed, update the Configuration section of `README.md` accordingly, including default values.
+
 Add an entry for each feature or fix in the `Features & Fixes` section of `README.md` with the date the feature was implemented, a short description and a "Details" column with links to the plan document, the feature document and the session conversation.
 
 Session transcripts live in `doc/sessions/`, one Markdown file per session. Each transcript must record the actual conversation as a sequence of `### User` and `### Assistant` sections. Summarise what the user asked and what the assistant did in each turn — do not paraphrase into phases or bullet-point summaries. Include a short `## Summary` at the top. See `doc/sessions/2026-03-10-ci-github-actions.md` as the reference format.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Set the following environment variables (or use a `.env` file):
 - `RAGTIME_LLM_PROVIDER` — LLM provider (`anthropic`, `openai`, etc.)
 - `RAGTIME_LLM_API_KEY` — API key for the LLM provider
 - `RAGTIME_LLM_MODEL` — LLM model name (default: `gpt-4.1-mini`)
+- `RAGTIME_SUMMARIZATION_PROVIDER` — Summarization LLM provider (default: `openai`)
+- `RAGTIME_SUMMARIZATION_API_KEY` — API key for the summarization provider
+- `RAGTIME_SUMMARIZATION_MODEL` — Summarization model name (default: `gpt-4.1-mini`)
 - `RAGTIME_TRANSCRIPTION_PROVIDER` — Transcription backend (`whisper_api`, `whisper_local`, etc.)
 - `RAGTIME_TRANSCRIPTION_API_KEY` — API key for transcription (if using API)
 - `RAGTIME_EMBEDDING_PROVIDER` — Embedding provider


### PR DESCRIPTION
## Problem

Step 7 (Summarize) introduced three `RAGTIME_SUMMARIZATION_*` environment variables but they were never added to the README's Configuration section. Additionally, AGENTS.md had no rule to prevent this from happening again.

## Changes

- **README.md** — Add missing `RAGTIME_SUMMARIZATION_PROVIDER` (default: `openai`), `RAGTIME_SUMMARIZATION_API_KEY`, and `RAGTIME_SUMMARIZATION_MODEL` (default: `gpt-4.1-mini`) to the Configuration section.
- **AGENTS.md** — Add rule requiring the README Configuration section to be updated whenever a `RAGTIME_*` environment variable is added, changed, or removed.