### PR TITLE
Update session transcript format for multi-session features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ Whenever a `RAGTIME_*` environment variable is added, changed, or removed, updat
 
 Add an entry for each feature or fix in the `Features & Fixes` section of `README.md` with the date the feature was implemented, a short description and a "Details" column with links to the plan document, the feature document and the session conversation.
 
-Session transcripts live in `doc/sessions/`, one Markdown file per session. Each transcript must record the actual conversation as a sequence of `### User` and `### Assistant` sections. Summarise what the user asked and what the assistant did in each turn — do not paraphrase into phases or bullet-point summaries. Include a short `## Summary` at the top. See `doc/sessions/2026-03-10-ci-github-actions.md` as the reference format.
+Session transcripts live in `doc/sessions/`, one Markdown file per feature. A feature typically spans multiple Claude Code sessions (e.g. planning, implementation, review) — the transcript must cover **all** of them.
+
+Each transcript must include:
+
+- **Session IDs** — list every Claude Code session ID that contributed to the feature, in a `## Sessions` section at the top.
+- **Summary** — a short `## Summary` describing what was accomplished across all sessions.
+- **Detailed conversation** — record the actual conversation as a sequence of `### User` and `### Assistant` sections. Summarise what the user asked and what the assistant did in each turn — do not paraphrase into phases or bullet-point summaries. Include the assistant's reasoning steps (e.g. what it explored, what alternatives it considered, why it chose a particular approach). When the conversation spans multiple sessions, separate them with a `## Session N` heading that includes the session ID.
+
+See `doc/sessions/2026-03-10-ci-github-actions.md` as the reference format.
 
 The commit for a given feature MUST contain the corresponding Markdown files for the plan, the feature documentation and the session.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Set the following environment variables (or use a `.env` file):
 | 2026-03-11 | Fix: Summarization respects episode language — summaries generated in the episode's language instead of defaulting to English | [feature](doc/features/fix-summarization-language.md), [session transcript](doc/sessions/2026-03-11-fix-summarization-language.md) |
 | 2026-03-13 | Step 8: Extract Entities — LLM-based entity extraction (artists, albums, venues, etc.) with independently configurable provider | [plan](doc/plans/step-08-extract-entities.md), [feature](doc/features/step-08-extract-entities.md), [session transcript](doc/sessions/2026-03-13-step-08-extract-entities.md) |
 | 2026-03-13 | Refactor: Split episode tests into a test package — 9 focused modules under `episodes/tests/`, one per component | [session transcript](doc/sessions/2026-03-13-refactor-episode-tests.md) |
+| 2026-03-13 | Docs: Multi-session transcript format — session IDs, reasoning steps, multi-session coverage | [feature](doc/features/session-transcript-format.md), [session transcript](doc/sessions/2026-03-13-session-transcript-format.md) |
 
 ## Built with AI
 

--- a/doc/features/session-transcript-format.md
+++ b/doc/features/session-transcript-format.md
@@ -1,0 +1,28 @@
+# Feature: Multi-session transcript format
+
+## Problem
+
+The session transcript guidelines in `AGENTS.md` assumed each feature corresponds to a single Claude Code session. In practice, features span multiple sessions — typically a planning session followed by one or more implementation sessions (the context is cleared between plan approval and implementation). The previous instructions did not capture session IDs or the assistant's reasoning steps, making transcripts less useful for understanding how decisions were made.
+
+## Changes
+
+Updated the session transcript paragraph in `AGENTS.md` to:
+
+- **Multi-session coverage** — A transcript file covers all sessions for a feature, not just one.
+- **Session IDs** — A `## Sessions` section lists every Claude Code session ID that contributed.
+- **Reasoning detail** — Transcripts must include the assistant's reasoning steps (what it explored, alternatives considered, rationale for chosen approach).
+- **Session separation** — When multiple sessions are involved, each is separated with a `## Session N` heading that includes the session ID.
+
+## Key parameters
+
+None — this is a documentation-only change.
+
+## Verification
+
+Review `AGENTS.md` and confirm the session transcript section reflects the new multi-session format with session IDs and reasoning requirements.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `AGENTS.md` | Replaced single-paragraph session transcript instructions with structured multi-session format |

--- a/doc/sessions/2026-03-13-session-transcript-format.md
+++ b/doc/sessions/2026-03-13-session-transcript-format.md
@@ -1,0 +1,32 @@
+# Session: Update session transcript format in AGENTS.md
+
+**Date:** 2026-03-13
+
+## Sessions
+
+- Session 1 (this session)
+
+## Summary
+
+Updated the session transcript guidelines in `AGENTS.md` to clarify that transcripts should cover all sessions for a feature (planning + implementation), include session IDs, and capture the assistant's reasoning steps.
+
+## Session 1
+
+### User
+
+Pointed out that the session transcript section in `AGENTS.md` says "one Markdown file per session" but features typically span multiple sessions (planning, implementation). Asked to update the text so that:
+- It is clear the transcript covers planning and implementation sessions (there may be more than one due to context clearing).
+- The transcript should contain session IDs.
+- The transcript should include detailed Markdown with model reasoning steps.
+
+### Assistant
+
+Read the current `AGENTS.md` session transcript paragraph and the reference transcript at `doc/sessions/2026-03-10-ci-github-actions.md` to understand the existing format. Replaced the single paragraph with a structured specification that requires: a `## Sessions` section listing all Claude Code session IDs, a `## Summary`, and detailed conversation sections with reasoning steps. Added guidance to separate multi-session transcripts with `## Session N` headings.
+
+### User
+
+Approved the changes and asked to document the change and create a PR.
+
+### Assistant
+
+Created feature branch `docs/session-transcript-format`. Wrote feature documentation at `doc/features/session-transcript-format.md` and this session transcript. Added a row to the Features & Fixes table in `README.md`. Committed all changes and opened a PR.


### PR DESCRIPTION
## Summary

- Update `AGENTS.md` session transcript guidelines to clarify that transcripts cover **all** sessions for a feature (planning + implementation), not just one
- Require session IDs in a dedicated `## Sessions` section
- Require assistant reasoning steps (what was explored, alternatives considered, rationale)
- Add `## Session N` headings to separate multi-session transcripts

## Test plan

- [x] Review updated `AGENTS.md` section for clarity
- [x] Verify feature doc and session transcript follow project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)