### PR TITLE
Rename RAGTIME_LLM_* to RAGTIME_SCRAPING_* for naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ uv run python manage.py runserver
 
 Set the following environment variables (or use a `.env` file):
 
-- `RAGTIME_LLM_PROVIDER` — LLM provider (`anthropic`, `openai`, etc.)
-- `RAGTIME_LLM_API_KEY` — API key for the LLM provider
-- `RAGTIME_LLM_MODEL` — LLM model name (default: `gpt-4.1-mini`)
+- `RAGTIME_SCRAPING_PROVIDER` — Scraping LLM provider (default: `openai`)
+- `RAGTIME_SCRAPING_API_KEY` — API key for the scraping LLM provider
+- `RAGTIME_SCRAPING_MODEL` — Scraping LLM model name (default: `gpt-4.1-mini`)
 - `RAGTIME_SUMMARIZATION_PROVIDER` — Summarization LLM provider (default: `openai`)
 - `RAGTIME_SUMMARIZATION_API_KEY` — API key for the summarization provider
 - `RAGTIME_SUMMARIZATION_MODEL` — Summarization model name (default: `gpt-4.1-mini`)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Set the following environment variables (or use a `.env` file):
 | 2026-03-13 | Step 8: Extract Entities — LLM-based entity extraction (artists, albums, venues, etc.) with independently configurable provider | [plan](doc/plans/step-08-extract-entities.md), [feature](doc/features/step-08-extract-entities.md), [session transcript](doc/sessions/2026-03-13-step-08-extract-entities.md) |
 | 2026-03-13 | Refactor: Split episode tests into a test package — 9 focused modules under `episodes/tests/`, one per component | [session transcript](doc/sessions/2026-03-13-refactor-episode-tests.md) |
 | 2026-03-13 | Docs: Multi-session transcript format — session IDs, reasoning steps, multi-session coverage | [feature](doc/features/session-transcript-format.md), [session transcript](doc/sessions/2026-03-13-session-transcript-format.md) |
+| 2026-03-13 | Refactor: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — align scraping provider naming with RAGTIME_\<PURPOSE\>_* convention | |
 
 ## Built with AI
 

--- a/episodes/providers/factory.py
+++ b/episodes/providers/factory.py
@@ -3,20 +3,20 @@ from django.conf import settings
 from .base import LLMProvider, TranscriptionProvider
 
 
-def get_llm_provider() -> LLMProvider:
-    provider_name = settings.RAGTIME_LLM_PROVIDER
-    api_key = settings.RAGTIME_LLM_API_KEY
-    model = settings.RAGTIME_LLM_MODEL
+def get_scraping_provider() -> LLMProvider:
+    provider_name = settings.RAGTIME_SCRAPING_PROVIDER
+    api_key = settings.RAGTIME_SCRAPING_API_KEY
+    model = settings.RAGTIME_SCRAPING_MODEL
 
     if not api_key:
-        raise ValueError("RAGTIME_LLM_API_KEY is not set")
+        raise ValueError("RAGTIME_SCRAPING_API_KEY is not set")
 
     if provider_name == "openai":
         from .openai import OpenAILLMProvider
 
         return OpenAILLMProvider(api_key=api_key, model=model)
 
-    raise ValueError(f"Unknown LLM provider: {provider_name}")
+    raise ValueError(f"Unknown scraping provider: {provider_name}")
 
 
 def get_transcription_provider() -> TranscriptionProvider:

--- a/episodes/scraper.py
+++ b/episodes/scraper.py
@@ -4,7 +4,7 @@ import httpx
 from bs4 import BeautifulSoup
 
 from .models import Episode
-from .providers.factory import get_llm_provider
+from .providers.factory import get_scraping_provider
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ def scrape_episode(episode_id: int) -> None:
             return
 
         # Extract metadata via LLM
-        provider = get_llm_provider()
+        provider = get_scraping_provider()
         result = provider.structured_extract(
             system_prompt=SCRAPE_SYSTEM_PROMPT,
             user_content=episode.scraped_html,

--- a/episodes/tests/test_scraper.py
+++ b/episodes/tests/test_scraper.py
@@ -44,9 +44,9 @@ class CleanHtmlTests(TestCase):
 
 
 @override_settings(
-    RAGTIME_LLM_PROVIDER="openai",
-    RAGTIME_LLM_API_KEY="test-key",
-    RAGTIME_LLM_MODEL="gpt-4.1-mini",
+    RAGTIME_SCRAPING_PROVIDER="openai",
+    RAGTIME_SCRAPING_API_KEY="test-key",
+    RAGTIME_SCRAPING_MODEL="gpt-4.1-mini",
 )
 class ScrapeEpisodeTests(TestCase):
     """Tests for the scrape_episode task function with mocked HTTP and LLM."""
@@ -87,7 +87,7 @@ class ScrapeEpisodeTests(TestCase):
         with patch("episodes.signals.async_task"):
             return Episode.objects.create(**kwargs)
 
-    @patch("episodes.scraper.get_llm_provider")
+    @patch("episodes.scraper.get_scraping_provider")
     @patch("episodes.scraper.fetch_html")
     def test_success_path(self, mock_fetch, mock_provider_factory):
         mock_fetch.return_value = self.SAMPLE_HTML
@@ -106,7 +106,7 @@ class ScrapeEpisodeTests(TestCase):
         self.assertEqual(episode.published_at, date(2026, 1, 15))
         self.assertNotEqual(episode.scraped_html, "")
 
-    @patch("episodes.scraper.get_llm_provider")
+    @patch("episodes.scraper.get_scraping_provider")
     @patch("episodes.scraper.fetch_html")
     def test_incomplete_extraction_needs_review(self, mock_fetch, mock_provider_factory):
         mock_fetch.return_value = self.SAMPLE_HTML
@@ -132,7 +132,7 @@ class ScrapeEpisodeTests(TestCase):
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.FAILED)
 
-    @patch("episodes.scraper.get_llm_provider")
+    @patch("episodes.scraper.get_scraping_provider")
     def test_reprocess_with_user_filled_fields(self, mock_provider_factory):
         """When user fills required fields and reprocesses, LLM is skipped."""
         episode = self._create_episode(
@@ -150,7 +150,7 @@ class ScrapeEpisodeTests(TestCase):
         # LLM should not have been called
         mock_provider_factory.assert_not_called()
 
-    @patch("episodes.scraper.get_llm_provider")
+    @patch("episodes.scraper.get_scraping_provider")
     @patch("episodes.scraper.fetch_html")
     def test_uses_cached_html_on_reprocess(self, mock_fetch, mock_provider_factory):
         """When scraped_html is already stored, HTTP fetch is skipped."""

--- a/ragtime/settings.py
+++ b/ragtime/settings.py
@@ -146,9 +146,9 @@ Q_CLUSTER = {
 }
 
 # RAGtime provider configuration
-RAGTIME_LLM_PROVIDER = os.getenv('RAGTIME_LLM_PROVIDER', 'openai')
-RAGTIME_LLM_API_KEY = os.getenv('RAGTIME_LLM_API_KEY', '')
-RAGTIME_LLM_MODEL = os.getenv('RAGTIME_LLM_MODEL', 'gpt-4.1-mini')
+RAGTIME_SCRAPING_PROVIDER = os.getenv('RAGTIME_SCRAPING_PROVIDER', 'openai')
+RAGTIME_SCRAPING_API_KEY = os.getenv('RAGTIME_SCRAPING_API_KEY', '')
+RAGTIME_SCRAPING_MODEL = os.getenv('RAGTIME_SCRAPING_MODEL', 'gpt-4.1-mini')
 
 # Audio processing
 RAGTIME_MAX_AUDIO_SIZE = 25 * 1024 * 1024  # 25MB — Whisper API limit


### PR DESCRIPTION
## Summary
- Rename `RAGTIME_LLM_PROVIDER`, `RAGTIME_LLM_API_KEY`, `RAGTIME_LLM_MODEL` → `RAGTIME_SCRAPING_PROVIDER`, `RAGTIME_SCRAPING_API_KEY`, `RAGTIME_SCRAPING_MODEL`
- Rename `get_llm_provider()` → `get_scraping_provider()` in the factory and all call sites
- Aligns scraping provider naming with the existing `RAGTIME_<PURPOSE>_*` convention (SUMMARIZATION, EXTRACTION, TRANSCRIPTION)

## Test plan
- [x] All 68 tests pass (`uv run python manage.py test episodes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)