### PR TITLE
Add plan and session transcript for scraping provider rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Set the following environment variables (or use a `.env` file):
 | 2026-03-13 | Step 8: Extract Entities — LLM-based entity extraction (artists, albums, venues, etc.) with independently configurable provider | [plan](doc/plans/step-08-extract-entities.md), [feature](doc/features/step-08-extract-entities.md), [session transcript](doc/sessions/2026-03-13-step-08-extract-entities.md) |
 | 2026-03-13 | Refactor: Split episode tests into a test package — 9 focused modules under `episodes/tests/`, one per component | [session transcript](doc/sessions/2026-03-13-refactor-episode-tests.md) |
 | 2026-03-13 | Docs: Multi-session transcript format — session IDs, reasoning steps, multi-session coverage | [feature](doc/features/session-transcript-format.md), [session transcript](doc/sessions/2026-03-13-session-transcript-format.md) |
-| 2026-03-13 | Refactor: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — align scraping provider naming with RAGTIME_\<PURPOSE\>_* convention | |
+| 2026-03-13 | Refactor: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — align scraping provider naming with RAGTIME_\<PURPOSE\>_* convention | [plan](doc/plans/refactor-rename-scraping-provider.md), [session transcript](doc/sessions/2026-03-13-rename-scraping-provider.md) |
 
 ## Built with AI
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Set the following environment variables (or use a `.env` file):
 | 2026-03-13 | Step 8: Extract Entities — LLM-based entity extraction (artists, albums, venues, etc.) with independently configurable provider | [plan](doc/plans/step-08-extract-entities.md), [feature](doc/features/step-08-extract-entities.md), [session transcript](doc/sessions/2026-03-13-step-08-extract-entities.md) |
 | 2026-03-13 | Refactor: Split episode tests into a test package — 9 focused modules under `episodes/tests/`, one per component | [session transcript](doc/sessions/2026-03-13-refactor-episode-tests.md) |
 | 2026-03-13 | Docs: Multi-session transcript format — session IDs, reasoning steps, multi-session coverage | [feature](doc/features/session-transcript-format.md), [session transcript](doc/sessions/2026-03-13-session-transcript-format.md) |
-| 2026-03-13 | Refactor: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — align scraping provider naming with RAGTIME_\<PURPOSE\>_* convention | [plan](doc/plans/refactor-rename-scraping-provider.md), [session transcript](doc/sessions/2026-03-13-rename-scraping-provider.md) |
+| 2026-03-13 | Refactor: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — align scraping provider naming with RAGTIME_\<PURPOSE\>_* convention | [plan](doc/plans/refactor-rename-scraping-provider.md), [feature](doc/features/refactor-rename-scraping-provider.md), [session transcript](doc/sessions/2026-03-13-rename-scraping-provider.md) |
 
 ## Built with AI
 

--- a/doc/features/refactor-rename-scraping-provider.md
+++ b/doc/features/refactor-rename-scraping-provider.md
@@ -1,0 +1,31 @@
+# Refactor: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_*
+
+## Problem
+
+The scraping provider used generic `RAGTIME_LLM_*` env vars and a `get_llm_provider()` factory function, while all other providers followed the `RAGTIME_<PURPOSE>_*` naming convention (`SUMMARIZATION`, `EXTRACTION`, `TRANSCRIPTION`). This inconsistency made it unclear that the "LLM" provider was specifically the scraping provider, and broke the pattern developers rely on when adding or configuring providers.
+
+## Changes
+
+- **`ragtime/settings.py`** — Renamed `RAGTIME_LLM_PROVIDER` → `RAGTIME_SCRAPING_PROVIDER`, `RAGTIME_LLM_API_KEY` → `RAGTIME_SCRAPING_API_KEY`, `RAGTIME_LLM_MODEL` → `RAGTIME_SCRAPING_MODEL`.
+- **`episodes/providers/factory.py`** — Renamed `get_llm_provider()` → `get_scraping_provider()`, updated all internal settings references and error messages.
+- **`episodes/scraper.py`** — Updated import and call site to use `get_scraping_provider`.
+- **`episodes/tests/test_scraper.py`** — Updated `@override_settings` to use `RAGTIME_SCRAPING_*` and all `@patch` decorators to reference `get_scraping_provider`.
+- **`README.md`** — Updated env var documentation and Features & Fixes table entry.
+
+## Verification
+
+```bash
+uv run python manage.py test episodes
+```
+
+All 68 tests pass.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `ragtime/settings.py` | Renamed 3 env var settings from `RAGTIME_LLM_*` to `RAGTIME_SCRAPING_*` |
+| `episodes/providers/factory.py` | Renamed `get_llm_provider()` → `get_scraping_provider()`, updated settings refs and error messages |
+| `episodes/scraper.py` | Updated import and call site |
+| `episodes/tests/test_scraper.py` | Updated `@override_settings` and 4 `@patch` decorators |
+| `README.md` | Updated env var docs and features table |

--- a/doc/features/refactor-rename-scraping-provider.md
+++ b/doc/features/refactor-rename-scraping-provider.md
@@ -12,6 +12,10 @@ The scraping provider used generic `RAGTIME_LLM_*` env vars and a `get_llm_provi
 - **`episodes/tests/test_scraper.py`** — Updated `@override_settings` to use `RAGTIME_SCRAPING_*` and all `@patch` decorators to reference `get_scraping_provider`.
 - **`README.md`** — Updated env var documentation and Features & Fixes table entry.
 
+## Key parameters
+
+None — this is a rename-only refactor with no new parameters or changed defaults.
+
 ## Verification
 
 ```bash

--- a/doc/plans/refactor-rename-scraping-provider.md
+++ b/doc/plans/refactor-rename-scraping-provider.md
@@ -1,0 +1,46 @@
+# Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — Plan
+
+## Context
+
+The `RAGTIME_LLM_*` env vars and `get_llm_provider()` are generic names for what is specifically the **scraping** LLM provider. Other providers already follow the `RAGTIME_<PURPOSE>_*` naming convention (SUMMARIZATION, EXTRACTION, TRANSCRIPTION). This refactor aligns the scraping provider with that convention.
+
+## Changes
+
+### 1. `ragtime/settings.py`
+
+Rename settings:
+- `RAGTIME_LLM_PROVIDER` → `RAGTIME_SCRAPING_PROVIDER`
+- `RAGTIME_LLM_API_KEY` → `RAGTIME_SCRAPING_API_KEY`
+- `RAGTIME_LLM_MODEL` → `RAGTIME_SCRAPING_MODEL`
+
+### 2. `episodes/providers/factory.py`
+
+- Rename `get_llm_provider()` → `get_scraping_provider()`
+- Update settings references inside to `RAGTIME_SCRAPING_*`
+- Update error message: `"RAGTIME_SCRAPING_API_KEY is not set"`
+
+### 3. `episodes/scraper.py`
+
+- Update import: `from .providers.factory import get_scraping_provider`
+- Update call: `provider = get_scraping_provider()`
+
+### 4. `episodes/tests/test_scraper.py`
+
+- Update `@override_settings` to use `RAGTIME_SCRAPING_*`
+- Update all `@patch("episodes.scraper.get_llm_provider")` → `@patch("episodes.scraper.get_scraping_provider")`
+
+### 5. `README.md`
+
+- Rename env vars in Configuration section
+- Add `(default: openai)` to the provider line
+- Add Features & Fixes table entry
+
+## Files modified
+
+| File | Action |
+|------|--------|
+| `ragtime/settings.py` | Edit — rename env var names |
+| `episodes/providers/factory.py` | Edit — rename function and references |
+| `episodes/scraper.py` | Edit — update import and call site |
+| `episodes/tests/test_scraper.py` | Edit — update settings overrides and patches |
+| `README.md` | Edit — update env var docs and features table |

--- a/doc/sessions/2026-03-13-rename-scraping-provider.md
+++ b/doc/sessions/2026-03-13-rename-scraping-provider.md
@@ -2,29 +2,29 @@
 
 **Date:** 2026-03-13
 
+## Sessions
+
+- `75420318-d8a7-44a3-855c-0d067ea8cef2` — planning and implementation
+
 ## Summary
 
 Renamed the generic `RAGTIME_LLM_*` env vars and `get_llm_provider()` factory function to `RAGTIME_SCRAPING_*` / `get_scraping_provider()`, aligning the scraping provider with the `RAGTIME_<PURPOSE>_*` naming convention used by all other providers.
 
 ## Conversation
 
-### Planning session
-
-#### User
+### User
 
 Asked to plan a rename of `RAGTIME_LLM_*` → `RAGTIME_SCRAPING_*` and `get_llm_provider` → `get_scraping_provider`.
 
-#### Assistant
+### Assistant
 
-Explored the codebase to find all references to the old names across settings, factory, scraper, tests, and README. Produced a plan covering 5 files with specific line references for each change.
+Explored the codebase to find all references to the old names across settings, factory, scraper, tests, and README. Entered plan mode and produced a plan covering 5 files with specific line references for each change: `ragtime/settings.py` (3 settings), `episodes/providers/factory.py` (function rename + settings refs + error message), `episodes/scraper.py` (import + call site), `episodes/tests/test_scraper.py` (`@override_settings` + 4 `@patch` decorators), and `README.md` (env var docs).
 
-### Implementation session
+### User
 
-#### User
+Approved the plan and asked to implement it.
 
-Provided the plan and asked to implement it.
-
-#### Assistant
+### Assistant
 
 Read all 5 files, applied the renames in parallel:
 - `ragtime/settings.py` — renamed 3 env var settings
@@ -34,3 +34,27 @@ Read all 5 files, applied the renames in parallel:
 - `README.md` — updated env var documentation and added Features & Fixes entry
 
 Ran `uv run python manage.py test episodes` — all 68 tests passed. Created branch, committed, pushed, and opened PR #21.
+
+### User
+
+Asked to create a PR.
+
+### Assistant
+
+Created branch `rename-llm-to-scraping-provider`, committed, pushed, and opened PR #21.
+
+### User
+
+Asked to document the refactoring in the README Features & Fixes table.
+
+### Assistant
+
+Added a new row to the Features & Fixes table linking to the plan and session transcript docs. Committed and pushed to the same PR.
+
+### User
+
+Asked to switch to main, pull, and create plan + session transcript docs in a separate PR.
+
+### Assistant
+
+Switched to main, pulled latest (which included the merged rename PR). Created `doc/plans/refactor-rename-scraping-provider.md` and `doc/sessions/2026-03-13-rename-scraping-provider.md`. Updated the README table entry with links to the new docs. Created branch `docs-rename-scraping-provider`, committed, pushed, and opened PR #22.

--- a/doc/sessions/2026-03-13-rename-scraping-provider.md
+++ b/doc/sessions/2026-03-13-rename-scraping-provider.md
@@ -1,0 +1,36 @@
+# Session: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_*
+
+**Date:** 2026-03-13
+
+## Summary
+
+Renamed the generic `RAGTIME_LLM_*` env vars and `get_llm_provider()` factory function to `RAGTIME_SCRAPING_*` / `get_scraping_provider()`, aligning the scraping provider with the `RAGTIME_<PURPOSE>_*` naming convention used by all other providers.
+
+## Conversation
+
+### Planning session
+
+#### User
+
+Asked to plan a rename of `RAGTIME_LLM_*` → `RAGTIME_SCRAPING_*` and `get_llm_provider` → `get_scraping_provider`.
+
+#### Assistant
+
+Explored the codebase to find all references to the old names across settings, factory, scraper, tests, and README. Produced a plan covering 5 files with specific line references for each change.
+
+### Implementation session
+
+#### User
+
+Provided the plan and asked to implement it.
+
+#### Assistant
+
+Read all 5 files, applied the renames in parallel:
+- `ragtime/settings.py` — renamed 3 env var settings
+- `episodes/providers/factory.py` — renamed function, updated settings references and error messages
+- `episodes/scraper.py` — updated import and call site
+- `episodes/tests/test_scraper.py` — updated `@override_settings` and 4 `@patch` decorators
+- `README.md` — updated env var documentation and added Features & Fixes entry
+
+Ran `uv run python manage.py test episodes` — all 68 tests passed. Created branch, committed, pushed, and opened PR #21.


### PR DESCRIPTION
## Summary
- Add implementation plan: `doc/plans/refactor-rename-scraping-provider.md`
- Add session transcript: `doc/sessions/2026-03-13-rename-scraping-provider.md`
- Update README Features & Fixes table entry with links to the new docs

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)