### PR TITLE
Fix UNIQUE constraint error in entity resolution

### DIFF
--- a/episodes/resolver.py
+++ b/episodes/resolver.py
@@ -140,7 +140,7 @@ def resolve_entities(episode_id: int) -> None:
                         if matched_id is not None and matched_id in existing_by_id:
                             entity = existing_by_id[matched_id]
                         else:
-                            entity = Entity.objects.create(
+                            entity, _created = Entity.objects.get_or_create(
                                 entity_type=entity_type,
                                 name=match["canonical_name"],
                             )

--- a/episodes/tests/test_resolve.py
+++ b/episodes/tests/test_resolve.py
@@ -242,6 +242,52 @@ class ResolveEntitiesTests(TestCase):
         self.assertEqual(Entity.objects.count(), 0)
         self.assertEqual(EntityMention.objects.count(), 0)
 
+    @patch("episodes.resolver.get_resolution_provider")
+    def test_unmatched_canonical_name_already_exists(self, mock_factory):
+        """LLM returns matched_entity_id=None but canonical_name already exists → reuse entity."""
+        from episodes.resolver import resolve_entities
+
+        existing = Entity.objects.create(
+            entity_type="artist", name="Django Reinhardt"
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.structured_extract.return_value = {
+            "matches": [
+                {
+                    "extracted_name": "Django Reinhardt",
+                    "canonical_name": "Django Reinhardt",
+                    "matched_entity_id": None,  # LLM didn't match
+                },
+            ],
+        }
+        mock_factory.return_value = mock_provider
+
+        entities_json = {
+            "artist": [
+                {"name": "Django Reinhardt", "context": "jazz guitarist"},
+            ],
+        }
+
+        episode = self._create_episode(
+            url="https://example.com/ep/res-dup",
+            status=Episode.Status.RESOLVING,
+            entities_json=entities_json,
+        )
+
+        with patch("episodes.signals.async_task"):
+            resolve_entities(episode.pk)
+
+        episode.refresh_from_db()
+        self.assertEqual(episode.status, Episode.Status.EMBEDDING)
+
+        # Should reuse existing entity, not crash
+        self.assertEqual(
+            Entity.objects.filter(entity_type="artist").count(), 1
+        )
+        mention = EntityMention.objects.get(episode=episode)
+        self.assertEqual(mention.entity, existing)
+
     def test_missing_entities_json(self):
         """Null entities_json → FAILED."""
         from episodes.resolver import resolve_entities


### PR DESCRIPTION
## Summary

- Use `get_or_create()` instead of `create()` in `resolver.py` when the LLM returns `matched_entity_id=None` but the `canonical_name` already exists in the database
- Add test covering this scenario

## Context

When processing episode 29, the resolver failed with:

```
sqlite3.IntegrityError: UNIQUE constraint failed: episodes_entity.entity_type, episodes_entity.name
```

The LLM returned `matched_entity_id: None` for an entity like "Django Reinhardt" that had already been created by a previous episode's resolution run. `Entity.objects.create()` then violated the `(entity_type, name)` unique constraint.

The fix replaces `create()` with `get_or_create()` so the existing entity is reused when the LLM fails to match it.

## Conversation

**User:**
> While testing locally, I see this error in the "resolving" state:
> ```
> Failed to resolve entities for episode 29
> sqlite3.IntegrityError: UNIQUE constraint failed: episodes_entity.entity_type, episodes_entity.name
> ```
> at `resolver.py:143`:
> ```python
> entity = Entity.objects.create(
>     entity_type=entity_type,
>     name=match["canonical_name"],
> )
> ```

**Claude:**
The LLM returns a canonical name that already exists in the database (e.g., "Django Reinhardt" as an artist was already created by a previous episode). `create()` fails on the unique constraint. Fix: use `get_or_create`.

Changed `Entity.objects.create()` to `Entity.objects.get_or_create()` at `resolver.py:143`. This handles the case where the LLM returns `matched_entity_id: None` (no match) but the `canonical_name` already exists in the database — for example, "Django Reinhardt" was created by a previous episode's resolution run.

## Test plan

- [x] New test `test_unmatched_canonical_name_already_exists` — verifies entity is reused, not duplicated
- [x] All 11 resolve tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)