### PR TITLE
Fix download task never queued after LLM extraction

### DIFF
--- a/episodes/scraper.py
+++ b/episodes/scraper.py
@@ -139,7 +139,18 @@ def scrape_episode(episode_id: int) -> None:
                 "Episode %s: incomplete metadata, needs review", episode_id
             )
 
-        episode.save()
+        episode.save(
+            update_fields=[
+                "status",
+                "title",
+                "description",
+                "image_url",
+                "language",
+                "audio_url",
+                "published_at",
+                "updated_at",
+            ]
+        )
 
     except Exception:
         logger.exception("Failed to scrape episode %s", episode_id)

--- a/episodes/tests/test_scraper.py
+++ b/episodes/tests/test_scraper.py
@@ -170,6 +170,25 @@ class ScrapeEpisodeTests(TestCase):
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.DOWNLOADING)
 
+    @patch("episodes.signals.async_task")
+    @patch("episodes.scraper.get_scraping_provider")
+    @patch("episodes.scraper.fetch_html")
+    def test_success_queues_download_task(self, mock_fetch, mock_provider_factory, mock_async):
+        """LLM extraction path triggers download task via signal."""
+        mock_fetch.return_value = self.SAMPLE_HTML
+        mock_provider = MagicMock()
+        mock_provider.structured_extract.return_value = self.LLM_COMPLETE_RESPONSE
+        mock_provider_factory.return_value = mock_provider
+
+        episode = Episode.objects.create(url="https://example.com/ep/6")
+        mock_async.reset_mock()
+
+        scrape_episode(episode.pk)
+
+        mock_async.assert_called_with(
+            "episodes.downloader.download_episode", episode.pk
+        )
+
     def test_nonexistent_episode(self):
         # Should not raise, just log error
         scrape_episode(99999)


### PR DESCRIPTION
## Summary

- Add `update_fields` to the scraper's `episode.save()` call after LLM metadata extraction so the post_save signal dispatches the download task

## Context

Episodes scraped via the LLM extraction path got stuck in "downloading" status forever. The scraper set `episode.status = Episode.Status.DOWNLOADING` but called `episode.save()` without `update_fields`. The `queue_next_step` signal requires `"status" in update_fields` to dispatch the next task, so the download was never queued.

The early-return path (line 113, reprocess after `needs_review`) already had `update_fields=["status", "updated_at"]` and worked correctly — only the LLM extraction path was affected.

## Conversation

**User:**
> I tried adding a new episode and the download gets stuck. In the logs I do not even see that the task is created. The last task I see is the scrape task completing. How do we know the download task was actually queued?

**Claude:**
Found the bug in `scraper.py:142` — `episode.save()` without `update_fields`. The signal at `signals.py:18` checks `if not update_fields or "status" not in update_fields: return`, so with a bare `save()` the download task is never dispatched. The early-return path at line 113 already had `update_fields=["status", "updated_at"]` which is why previously scraped episodes worked. Fixed by adding `update_fields` listing all modified fields to the save call.

## Test plan

- [x] New test `test_success_queues_download_task` — verifies `async_task("episodes.downloader.download_episode", ...)` is called after LLM extraction
- [x] All 23 scraper + signal tests pass
- [x] Manually verified with Chet Baker episode — download proceeds after scraping

🤖 Generated with [Claude Code](https://claude.com/claude-code)