### PR TITLE
Replace httpx MP3 download with wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ Scott responds in the user's language, regardless of the source episode's langua
 
 ### Prerequisites
 
-- Python 3.13+
-- uv
-- ffmpeg (for audio downsampling)
+- [Python 3.13+](https://www.python.org/downloads/)
+- [uv](https://docs.astral.sh/uv/)
+- [ffmpeg](https://ffmpeg.org/) (for audio downsampling)
+- [wget](https://www.gnu.org/software/wget/) (for audio downloading)
 
 ### Installation
 

--- a/episodes/downloader.py
+++ b/episodes/downloader.py
@@ -1,7 +1,8 @@
 import logging
+import os
+import subprocess
 import tempfile
 
-import httpx
 from django.conf import settings
 from django.core.files import File
 
@@ -9,8 +10,7 @@ from .models import Episode
 
 logger = logging.getLogger(__name__)
 
-DOWNLOAD_TIMEOUT = 600  # 10 minutes for large audio files
-CHUNK_SIZE = 64 * 1024  # 64KB chunks
+DOWNLOAD_TIMEOUT = 60  # 1 minute
 
 
 def download_episode(episode_id: int) -> None:
@@ -29,18 +29,15 @@ def download_episode(episode_id: int) -> None:
         return
 
     try:
-        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
-            with httpx.stream(
-                "GET",
-                episode.audio_url,
-                follow_redirects=True,
-                timeout=DOWNLOAD_TIMEOUT,
-                headers={"User-Agent": "RAGtime/0.1 (podcast audio downloader)"},
-            ) as response:
-                response.raise_for_status()
-                for chunk in response.iter_bytes(chunk_size=CHUNK_SIZE):
-                    tmp.write(chunk)
-            tmp_path = tmp.name
+        tmp = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        tmp_path = tmp.name
+        tmp.close()
+
+        subprocess.run(
+            ["wget", "-q", "-O", tmp_path, episode.audio_url],
+            check=True,
+            timeout=DOWNLOAD_TIMEOUT,
+        )
 
         # Save to FileField
         filename = f"{episode.pk}.mp3"
@@ -69,8 +66,6 @@ def download_episode(episode_id: int) -> None:
         episode.status = Episode.Status.FAILED
         episode.save(update_fields=["status", "error_message", "updated_at"])
     finally:
-        import os
-
         try:
             os.unlink(tmp_path)
         except (OSError, UnboundLocalError):

--- a/episodes/tests/test_download.py
+++ b/episodes/tests/test_download.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+import subprocess
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
@@ -13,19 +14,19 @@ class DownloadEpisodeTests(TestCase):
         with patch("episodes.signals.async_task"):
             return Episode.objects.create(**kwargs)
 
-    @patch("episodes.downloader.httpx.stream")
-    def test_success_small_file(self, mock_stream):
+    @patch("episodes.downloader.subprocess.run")
+    def test_success_small_file(self, mock_run):
         """Download ≤ 25MB → status transcribing."""
         from episodes.downloader import download_episode
 
-        # Mock streaming response with small content
         audio_data = b"fake-mp3-data" * 100  # small file
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.iter_bytes.return_value = [audio_data]
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_stream.return_value = mock_response
+
+        def write_fake_audio(cmd, **kwargs):
+            # cmd is ["wget", "-q", "-O", tmp_path, url]
+            with open(cmd[3], "wb") as f:
+                f.write(audio_data)
+
+        mock_run.side_effect = write_fake_audio
 
         episode = self._create_episode(
             url="https://example.com/ep/dl-1",
@@ -40,19 +41,19 @@ class DownloadEpisodeTests(TestCase):
         self.assertEqual(episode.status, Episode.Status.TRANSCRIBING)
         self.assertTrue(episode.audio_file)
 
-    @patch("episodes.downloader.httpx.stream")
+    @patch("episodes.downloader.subprocess.run")
     @override_settings(RAGTIME_MAX_AUDIO_SIZE=100)  # 100 bytes limit
-    def test_large_file_triggers_resize(self, mock_stream):
+    def test_large_file_triggers_resize(self, mock_run):
         """Download > max size → status resizing."""
         from episodes.downloader import download_episode
 
         audio_data = b"x" * 200  # exceeds 100 byte limit
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.iter_bytes.return_value = [audio_data]
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_stream.return_value = mock_response
+
+        def write_fake_audio(cmd, **kwargs):
+            with open(cmd[3], "wb") as f:
+                f.write(audio_data)
+
+        mock_run.side_effect = write_fake_audio
 
         episode = self._create_episode(
             url="https://example.com/ep/dl-2",
@@ -66,12 +67,12 @@ class DownloadEpisodeTests(TestCase):
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.RESIZING)
 
-    @patch("episodes.downloader.httpx.stream")
-    def test_http_error_sets_failed(self, mock_stream):
-        """HTTP error → status failed with error_message."""
+    @patch("episodes.downloader.subprocess.run")
+    def test_wget_error_sets_failed(self, mock_run):
+        """wget error → status failed with error_message."""
         from episodes.downloader import download_episode
 
-        mock_stream.side_effect = Exception("Connection refused")
+        mock_run.side_effect = subprocess.CalledProcessError(8, "wget")
 
         episode = self._create_episode(
             url="https://example.com/ep/dl-3",
@@ -84,7 +85,7 @@ class DownloadEpisodeTests(TestCase):
 
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.FAILED)
-        self.assertIn("Connection refused", episode.error_message)
+        self.assertIn("wget", episode.error_message)
 
     def test_nonexistent_episode(self):
         """Non-existent episode ID → no crash."""


### PR DESCRIPTION
## Summary

- Replace httpx streaming download with `subprocess.run(["wget", ...])` in `episodes/downloader.py`
- Update download tests to mock `subprocess.run` instead of `httpx.stream`
- Add wget to README prerequisites, add hyperlinks to all prerequisite tools

## Context

Some podcast websites block MP3 downloads when the request uses a custom User-Agent header (`RAGtime/0.1`). Using wget's standard User-Agent avoids this issue.

## Test plan

- [x] All 5 download tests pass
- [x] Manually verified end-to-end download with BR podcast episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)