### PR TITLE
Fix: Move "Name" to first column in Entity admin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ uv run python manage.py runserver
 | 2026-03-13 | Step 9: Resolve Entities — LLM-based entity resolution against existing DB records with fuzzy matching, canonical naming, and cross-language support | [plan](doc/plans/step-09-resolve-entities.md), [feature](doc/features/step-09-resolve-entities.md), [session transcript](doc/sessions/2026-03-13-step-09-resolve-entities.md) |
 | 2026-03-14 | Fix: Download task never queued after LLM extraction — scraper's bare `save()` missed `update_fields`, so the post_save signal never dispatched the download task | [PR](https://github.com/rafacm/ragtime/pull/27) |
 | 2026-03-14 | Replace httpx MP3 download with wget — avoids User-Agent blocking by podcast websites, adds wget to prerequisites | [PR](https://github.com/rafacm/ragtime/pull/28) |
+| 2026-03-14 | Fix: Move "Name" to first column in Entity admin list — makes Name the clickable link to the detail page | [PR](https://github.com/rafacm/ragtime/pull/31) |
 
 ## Built with AI
 

--- a/episodes/admin.py
+++ b/episodes/admin.py
@@ -135,7 +135,7 @@ class EpisodeAdmin(admin.ModelAdmin):
 
 @admin.register(Entity)
 class EntityAdmin(admin.ModelAdmin):
-    list_display = ("entity_type", "name", "mention_count", "created_at")
+    list_display = ("name", "entity_type", "mention_count", "created_at")
     list_filter = ("entity_type",)
     search_fields = ("name",)
     readonly_fields = ("entity_type", "name", "created_at", "updated_at")


### PR DESCRIPTION
## Summary
- Swaps column order in `EntityAdmin.list_display` so **Name** appears first instead of Entity Type
- Django admin automatically makes the first column the clickable link to the detail page, so this makes Name the link

## Conversation

User noticed that "Entity Type" was the first column (and clickable link) in the Entity admin list page. Since "Name" is more useful as the primary identifier, we swapped the order in `list_display`.

**Change in `episodes/admin.py:138`:**
```python
# Before
list_display = ("entity_type", "name", "mention_count", "created_at")

# After
list_display = ("name", "entity_type", "mention_count", "created_at")
```

## Test plan
- [x] Visit `/admin/episodes/entity/` and confirm "Name" is the first column
- [x] Confirm "Name" links to the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)