### PR TITLE
Extract configuration vars into .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,46 @@
+# Scraping LLM provider (default: openai)
+RAGTIME_SCRAPING_PROVIDER=
+# API key for the scraping LLM provider
+RAGTIME_SCRAPING_API_KEY=
+# Scraping LLM model name (default: gpt-4.1-mini)
+RAGTIME_SCRAPING_MODEL=
+
+# Summarization LLM provider (default: openai)
+RAGTIME_SUMMARIZATION_PROVIDER=
+# API key for the summarization provider
+RAGTIME_SUMMARIZATION_API_KEY=
+# Summarization model name (default: gpt-4.1-mini)
+RAGTIME_SUMMARIZATION_MODEL=
+
+# Entity extraction LLM provider (default: openai)
+RAGTIME_EXTRACTION_PROVIDER=
+# API key for the entity extraction provider
+RAGTIME_EXTRACTION_API_KEY=
+# Entity extraction model name (default: gpt-4.1-mini)
+RAGTIME_EXTRACTION_MODEL=
+
+# Entity resolution LLM provider (default: openai)
+RAGTIME_RESOLUTION_PROVIDER=
+# API key for the entity resolution provider
+RAGTIME_RESOLUTION_API_KEY=
+# Entity resolution model name (default: gpt-4.1-mini)
+RAGTIME_RESOLUTION_MODEL=
+
+# Transcription backend (whisper_api, whisper_local, etc.)
+RAGTIME_TRANSCRIPTION_PROVIDER=
+# API key for transcription (if using API)
+RAGTIME_TRANSCRIPTION_API_KEY=
+
+# Embedding provider
+RAGTIME_EMBEDDING_PROVIDER=
+# API key for embeddings (if using API)
+RAGTIME_EMBEDDING_API_KEY=
+
+# Vector store backend (chroma, etc.)
+RAGTIME_VECTOR_STORE=
+# ChromaDB server host (default: localhost, omit for embedded/local mode)
+RAGTIME_CHROMA_HOST=
+# ChromaDB server port (default: 8000)
+RAGTIME_CHROMA_PORT=
+# ChromaDB collection name (default: ragtime)
+RAGTIME_CHROMA_COLLECTION=

--- a/README.md
+++ b/README.md
@@ -121,27 +121,7 @@ uv run python manage.py runserver
 
 🪄 You can run `uv run python manage.py configure` to launch an interactive setup wizard for all `RAGTIME_*` env vars.
 
-✍️ Alternatively, you can manually set the following environment variables (or use a `.env` file):
-- `RAGTIME_SCRAPING_PROVIDER` — Scraping LLM provider (default: `openai`)
-- `RAGTIME_SCRAPING_API_KEY` — API key for the scraping LLM provider
-- `RAGTIME_SCRAPING_MODEL` — Scraping LLM model name (default: `gpt-4.1-mini`)
-- `RAGTIME_SUMMARIZATION_PROVIDER` — Summarization LLM provider (default: `openai`)
-- `RAGTIME_SUMMARIZATION_API_KEY` — API key for the summarization provider
-- `RAGTIME_SUMMARIZATION_MODEL` — Summarization model name (default: `gpt-4.1-mini`)
-- `RAGTIME_EXTRACTION_PROVIDER` — Entity extraction LLM provider (default: `openai`)
-- `RAGTIME_EXTRACTION_API_KEY` — API key for the entity extraction provider
-- `RAGTIME_EXTRACTION_MODEL` — Entity extraction model name (default: `gpt-4.1-mini`)
-- `RAGTIME_RESOLUTION_PROVIDER` — Entity resolution LLM provider (default: `openai`)
-- `RAGTIME_RESOLUTION_API_KEY` — API key for the entity resolution provider
-- `RAGTIME_RESOLUTION_MODEL` — Entity resolution model name (default: `gpt-4.1-mini`)
-- `RAGTIME_TRANSCRIPTION_PROVIDER` — Transcription backend (`whisper_api`, `whisper_local`, etc.)
-- `RAGTIME_TRANSCRIPTION_API_KEY` — API key for transcription (if using API)
-- `RAGTIME_EMBEDDING_PROVIDER` — Embedding provider
-- `RAGTIME_EMBEDDING_API_KEY` — API key for embeddings (if using API)
-- `RAGTIME_VECTOR_STORE` — Vector store backend (`chroma`, etc.)
-- `RAGTIME_CHROMA_HOST` — ChromaDB server host (default: `localhost`, omit for embedded/local mode)
-- `RAGTIME_CHROMA_PORT` — ChromaDB server port (default: `8000`)
-- `RAGTIME_CHROMA_COLLECTION` — ChromaDB collection name (default: `ragtime`)
+✍️ Alternatively, copy [`.env.sample`](.env.sample) to `.env` and fill in your values.
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
- Moved the inline list of `RAGTIME_*` environment variables from the README into a dedicated `.env.sample` file
- Users can now `cp .env.sample .env` and fill in their values directly
- Simplified the README Configuration section to a one-liner pointing to the sample file

## Test plan
- [x] Verify `.env.sample` contains all previously listed env vars with correct comments and defaults
- [x] Verify README links to `.env.sample` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)