### PR TITLE
Restructure README pipeline section as numbered emoji list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Use `uv` for everything — never `pip install` directly.
 
 **Provider abstraction:** LLM, transcription, and embedding backends are pluggable via abstract base classes in `episodes/providers/base.py` with a factory in `episodes/providers/factory.py`. Configured through `RAGTIME_*` environment variables.
 
-**12-step pipeline** (`episodes/pipeline.py`): submit → dedup → scrape → download → resize → transcribe → summarize → chunk → extract → resolve → embed → ready. Each step updates the episode status. Failures set status to `failed`. Runs async via Django Q2.
+**11-step pipeline** (`episodes/pipeline.py`): submit → scrape → download → resize → transcribe → summarize → chunk → extract → resolve → embed → ready. Each step updates the episode status. Failures set status to `failed`. Runs async via Django Q2.
 
 **Entity resolution:** After extraction, entities (artists, bands, albums, venues, sessions, labels, years) are resolved against existing DB records using LLM-based fuzzy matching to prevent duplicates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Restructure README Processing Pipeline from table to numbered emoji list, fold Extracted Entities section into Step 9
+- Restructure README Processing Pipeline from table to numbered emoji list, fold Extracted Entities section into Step 9 — [PR](https://github.com/rafacm/ragtime/pull/43)
 
 ## 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2026-03-15
+
+### Changed
+
+- Restructure README Processing Pipeline from table to numbered emoji list, fold Extracted Entities section into Step 9
+
 ## 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,34 +33,20 @@ RAGtime is a Django application for ingesting jazz-related podcast episodes. It 
 
 Each episode goes through the following steps, with status tracked throughout:
 
-| Step | Description | Status |
-|------|-------------|--------|
-| 1. Submit | User submits an episode page URL | `pending` |
-| 2. Dedup | Check if episode URL already exists | `pending` |
-| 3. Scrape | Extract metadata (title, description, date, image) + detect language | `scraping` |
-| 4. Download | Find and download the audio file | `downloading` |
-| 5. Resize | If audio > 25MB, downsample with ffmpeg | `downloading` |
-| 6. Transcribe | Whisper transcription with detected language, segment + word timestamps | `transcribing` |
-| 7. Summarize | LLM-generated episode summary | `summarizing` |
-| 8. Chunk | Split transcript by Whisper segments | `chunking` |
-| 9. Extract | LLM-based entity extraction (artists, albums, venues, etc.) | `extracting` |
-| 10. Resolve | LLM-based entity resolution against existing entities in DB | `resolving` |
-| 11. Embed | Generate multilingual embeddings and store in ChromaDB | `embedding` |
-| 12. Ready | Episode available for Scott to reference | `ready` |
+1. 📥 **Submit** (status: `pending`): User submits an episode page URL.
+2. 🔁 **Dedup** (status: `pending`): Check if episode URL already exists.
+3. 🕷️ **Scrape** (status: `scraping`): Extract metadata (title, description, date, image) + detect language.
+4. ⬇️ **Download** (status: `downloading`): Find and download the audio file.
+5. 🔊 **Resize** (status: `downloading`): If audio > 25MB, downsample with ffmpeg.
+6. 🎙️ **Transcribe** (status: `transcribing`): Whisper transcription with detected language, segment + word timestamps.
+7. 📋 **Summarize** (status: `summarizing`): LLM-generated episode summary.
+8. ✂️ **Chunk** (status: `chunking`): Split transcript by Whisper segments.
+9. 🔍 **Extract** (status: `extracting`): LLM-based entity extraction. Entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) are stored in the database and managed via Django admin. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with `uv run python manage.py load_entity_types`. New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity).
+10. 🧩 **Resolve** (status: `resolving`): LLM-based entity resolution against existing entities in DB.
+11. 📐 **Embed** (status: `embedding`): Generate multilingual embeddings and store in ChromaDB.
+12. ✅ **Ready** (status: `ready`): Episode available for Scott to reference.
 
 Any step failure marks the episode as `failed`.
-
-## Extracted Entities
-
-Step 9 extracts jazz entity types from each episode transcript. Entity types are stored in the database and managed via Django admin.
-
-An initial set of 14 entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml). Load them with:
-
-```bash
-uv run python manage.py load_entity_types
-```
-
-New entity types can be added through Django admin. Existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each episode goes through the following steps, with status tracked throughout:
 2. 🔁 **Dedup** (status: `pending`): Check if episode URL already exists.
 3. 🕷️ **Scrape** (status: `scraping`): Extract metadata (title, description, date, image) + detect language.
 4. ⬇️ **Download** (status: `downloading`): Find and download the audio file.
-5. 🔊 **Resize** (status: `downloading`): If audio > 25MB, downsample with ffmpeg.
+5. 🔊 **Resize** (status: `resizing`): If audio > 25MB, downsample with ffmpeg.
 6. 🎙️ **Transcribe** (status: `transcribing`): Whisper transcription with detected language, segment + word timestamps.
 7. 📋 **Summarize** (status: `summarizing`): LLM-generated episode summary.
 8. ✂️ **Chunk** (status: `chunking`): Split transcript by Whisper segments.

--- a/README.md
+++ b/README.md
@@ -33,18 +33,17 @@ RAGtime is a Django application for ingesting jazz-related podcast episodes. It 
 
 Each episode goes through the following steps, with status tracked throughout:
 
-1. 📥 **Submit** (status: `pending`): User submits an episode page URL.
-2. 🔁 **Dedup** (status: `pending`): Check if episode URL already exists.
-3. 🕷️ **Scrape** (status: `scraping`): Extract metadata (title, description, date, image) + detect language.
-4. ⬇️ **Download** (status: `downloading`): Find and download the audio file.
-5. 🔊 **Resize** (status: `resizing`): If audio > 25MB, downsample with ffmpeg.
-6. 🎙️ **Transcribe** (status: `transcribing`): Whisper transcription with detected language, segment + word timestamps.
-7. 📋 **Summarize** (status: `summarizing`): LLM-generated episode summary.
-8. ✂️ **Chunk** (status: `chunking`): Split transcript by Whisper segments.
-9. 🔍 **Extract** (status: `extracting`): LLM-based entity extraction. Entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) are stored in the database and managed via Django admin. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with `uv run python manage.py load_entity_types`. New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity).
-10. 🧩 **Resolve** (status: `resolving`): LLM-based entity resolution against existing entities in DB.
-11. 📐 **Embed** (status: `embedding`): Generate multilingual embeddings and store in ChromaDB.
-12. ✅ **Ready** (status: `ready`): Episode available for Scott to reference.
+1. 📥 **Submit** (status: `pending`): User submits an episode page URL. Duplicate URLs are detected and the user is notified.
+2. 🕷️ **Scrape** (status: `scraping`): Extract metadata (title, description, date, image) + detect language.
+3. ⬇️ **Download** (status: `downloading`): Find and download the audio file.
+4. 🔊 **Resize** (status: `resizing`): If audio > 25MB, downsample with ffmpeg.
+5. 🎙️ **Transcribe** (status: `transcribing`): Whisper transcription with detected language, segment + word timestamps.
+6. 📋 **Summarize** (status: `summarizing`): LLM-generated episode summary.
+7. ✂️ **Chunk** (status: `chunking`): Split transcript by Whisper segments.
+8. 🔍 **Extract** (status: `extracting`): LLM-based entity extraction. Entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) are stored in the database and managed via Django admin. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with `uv run python manage.py load_entity_types`. New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity).
+9. 🧩 **Resolve** (status: `resolving`): LLM-based entity resolution against existing entities in DB.
+10. 📐 **Embed** (status: `embedding`): Generate multilingual embeddings and store in ChromaDB.
+11. ✅ **Ready** (status: `ready`): Episode available for Scott to reference.
 
 Any step failure marks the episode as `failed`.
 


### PR DESCRIPTION
## Summary

- Restructure README Processing Pipeline from table format to numbered emoji list for consistency with the Features section
- Fold the standalone "Extracted Entities" section into pipeline Step 8 (Extract) — no information lost
- Merge Submit and Dedup into a single step (12 → 11 steps), since dedup is enforced by a DB uniqueness constraint on episode URL, not a separate processing step
- Fix Resize step status from `downloading` to `resizing` to match the actual implementation
- Update AGENTS.md pipeline reference (12-step → 11-step)

**Note:** Historical references to "12 steps" and "Dedup" in session transcripts, plan/feature docs, and changelog entries are intentionally left unchanged as they are historical records.

## Test plan

- [ ] Verify rendered README pipeline list displays correctly on GitHub
- [ ] Confirm all 11 pipeline steps are present with correct statuses
- [ ] Confirm entity types info and `load_entity_types` command appear in Step 8 (Extract)
- [ ] Verify the "Extracted Entities" section is fully removed
- [ ] Verify AGENTS.md references 11-step pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the processing pipeline into an emoji-prefixed inline step list and renumbered steps (dedup removed; now 11 steps).
  * Merged the former "Extracted Entities" into Step 8 and expanded entity-type lifecycle guidance: initial 14 types, loading command, admin UI for add/deactivate, and protection against deleting types in use.
  * Minor wording and formatting updates across README and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->