### PR TITLE
Add adaptive audio resize tiers based on episode duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 2026-03-15
 
+### Added
+
+- Adaptive Audio Resize Tiers — select the gentlest ffmpeg settings that fit under the Whisper API size limit based on episode duration, instead of always using the most aggressive compression — [plan](doc/plans/adaptive-audio-resize-tiers.md), [feature](doc/features/adaptive-audio-resize-tiers.md), [planning session](doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md), [implementation session](doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md)
+
 ### Changed
 
 - Merge Resize into Transcribe — absorb ffmpeg downsampling into the transcribe step, reducing the pipeline from 11 to 10 steps. Resize was a transcription provider implementation detail, not a meaningful domain event — [plan](doc/plans/merge-resize-into-transcribe.md), [feature](doc/features/merge-resize-into-transcribe.md), [planning session](doc/sessions/2026-03-15-merge-resize-into-transcribe-planning-session.md), [implementation session](doc/sessions/2026-03-15-merge-resize-into-transcribe-implementation-session.md)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Download the audio file and extract duration.
 
 #### 4. 🎙️ Transcribe (status: `transcribing`)
 
-If audio exceeds the file-size limit (default 25 MB), adaptively downsample with ffmpeg — the gentlest settings that fit are chosen based on episode duration (from 128 kbps for slightly oversized files down to 32 kbps for very long episodes). Whisper transcription with detected language, producing segment and word-level timestamps.
+Send audio to the Whisper API (or a local Whisper-compatible endpoint) for transcription, producing segment and word-level timestamps in the detected language. Files that exceed the configurable size limit (default 25 MB) are [adaptively downsampled](doc/features/adaptive-audio-resize-tiers.md) with ffmpeg — the gentlest settings that fit are chosen based on episode duration, from 128 kbps for slightly oversized files down to 32 kbps for very long episodes.
 
 #### 5. 📋 Summarize (status: `summarizing`)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Download the audio file and extract duration.
 
 #### 4. 🎙️ Transcribe (status: `transcribing`)
 
-If audio exceeds the file-size limit (default 25 MB), downsample with ffmpeg first. Whisper transcription with detected language, producing segment and word-level timestamps.
+If audio exceeds the file-size limit (default 25 MB), adaptively downsample with ffmpeg — the gentlest settings that fit are chosen based on episode duration (from 128 kbps for slightly oversized files down to 32 kbps for very long episodes). Whisper transcription with detected language, producing segment and word-level timestamps.
 
 #### 5. 📋 Summarize (status: `summarizing`)
 

--- a/doc/features/adaptive-audio-resize-tiers.md
+++ b/doc/features/adaptive-audio-resize-tiers.md
@@ -1,0 +1,39 @@
+# Adaptive Audio Resize Tiers
+
+## Problem
+
+The audio resize step always applied the most aggressive ffmpeg settings (mono/22050Hz/64kbps) regardless of how much reduction was actually needed. A slightly oversized 26MB file got the same heavy compression as a 100MB file, unnecessarily degrading transcription quality.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `episodes/transcriber.py` | Added `RESIZE_TIERS` (5 tiers from 128k to 32k), `RESIZE_SAFETY_MARGIN`, `_select_resize_tier()` function; updated `_resize_if_needed` to use dynamic tier selection with info logging |
+| `episodes/tests/test_transcribe.py` | Added `ResizeTierSelectionTests` (4 unit tests for tier selection logic) and 2 integration tests for duration-based and fallback tier selection |
+
+## Key Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `RESIZE_SAFETY_MARGIN` | 1.10 | 10% overhead accounts for MP3 container/framing beyond raw bitrate calculation |
+| Tier 0 | mono/44100/128k | Gentlest reduction — for files just slightly over the limit |
+| Tier 4 | mono/16000/32k | Most aggressive — last resort and fallback when duration is unknown |
+
+## Verification
+
+```bash
+uv run python manage.py test episodes.tests.test_transcribe
+```
+
+All 18 tests pass. New tests verify:
+- Short episode (600s) selects tier 0 (128k)
+- Medium episode (3600s) selects tier 3 (48k)
+- Very long episode (20000s) where no tier fits returns `None`
+- `None` duration returns tier 4
+- Integration: episode with `duration=600` gets 128k ffmpeg args
+- Integration: episode without duration gets 32k ffmpeg args
+
+## Files Modified
+
+- `episodes/transcriber.py` — Added tier constants, `_select_resize_tier()`, updated `_resize_if_needed` to use adaptive tiers
+- `episodes/tests/test_transcribe.py` — Added `ResizeTierSelectionTests` class and 2 new integration tests

--- a/doc/features/adaptive-audio-resize-tiers.md
+++ b/doc/features/adaptive-audio-resize-tiers.md
@@ -8,8 +8,8 @@ The audio resize step always applied the most aggressive ffmpeg settings (mono/2
 
 | File | Change |
 |------|--------|
-| `episodes/transcriber.py` | Added `RESIZE_TIERS` (5 tiers from 128k to 32k), `RESIZE_SAFETY_MARGIN`, `_select_resize_tier()` function; updated `_resize_if_needed` to use dynamic tier selection with info logging |
-| `episodes/tests/test_transcribe.py` | Added `ResizeTierSelectionTests` (4 unit tests for tier selection logic) and 2 integration tests for duration-based and fallback tier selection |
+| `episodes/transcriber.py` | Added `RESIZE_TIERS` (5 tiers from 128k to 32k), `RESIZE_SAFETY_MARGIN`, `_select_resize_tier()` function; updated `_resize_if_needed` to use dynamic tier selection with retry loop and info logging; added `-hide_banner -loglevel error` to ffmpeg args |
+| `episodes/tests/test_transcribe.py` | Added `ResizeTierSelectionTests` (4 unit tests for tier selection logic) and 3 integration tests for duration-based tier selection, retry on oversize, and fallback |
 
 ## Key Parameters
 
@@ -25,15 +25,16 @@ The audio resize step always applied the most aggressive ffmpeg settings (mono/2
 uv run python manage.py test episodes.tests.test_transcribe
 ```
 
-All 18 tests pass. New tests verify:
+All 19 tests pass. New tests verify:
 - Short episode (600s) selects tier 0 (128k)
 - Medium episode (3600s) selects tier 3 (48k)
 - Very long episode (20000s) where no tier fits returns `None`
 - `None` duration returns tier 4
-- Integration: episode with `duration=600` gets 128k ffmpeg args
+- Integration: episode with `duration=10` gets 128k ffmpeg args
 - Integration: episode without duration gets 32k ffmpeg args
+- Integration: retry with next tier when first tier output exceeds limit
 
 ## Files Modified
 
-- `episodes/transcriber.py` — Added tier constants, `_select_resize_tier()`, updated `_resize_if_needed` to use adaptive tiers
-- `episodes/tests/test_transcribe.py` — Added `ResizeTierSelectionTests` class and 2 new integration tests
+- `episodes/transcriber.py` — Added tier constants, `_select_resize_tier()`, updated `_resize_if_needed` to use adaptive tiers with retry loop and `-hide_banner -loglevel error` ffmpeg flags
+- `episodes/tests/test_transcribe.py` — Added `ResizeTierSelectionTests` class and 3 new integration tests

--- a/doc/plans/adaptive-audio-resize-tiers.md
+++ b/doc/plans/adaptive-audio-resize-tiers.md
@@ -1,0 +1,41 @@
+# Adaptive Audio Resize Tiers
+
+## Context
+
+The `_resize_if_needed` function in `episodes/transcriber.py` always applies the most aggressive ffmpeg settings (mono/22kHz/64kbps) when an audio file exceeds the 25MB Whisper API limit. A 26MB file of a 10-minute episode gets the same treatment as a 100MB file of a 3-hour episode, degrading transcription quality unnecessarily. Since we now have the episode `duration` (seconds, set during download), we can calculate the minimum reduction needed and pick the gentlest settings that fit.
+
+## Approach
+
+Define a tier list ordered from highest to lowest quality. For each tier, estimate the output size using `(bitrate / 8) * duration * 1.10` (10% safety margin for MP3 overhead). Pick the first tier whose estimate fits under the limit.
+
+### Tiers
+
+| Tier | Channels | Sample Rate | Bitrate | Use case |
+|------|----------|-------------|---------|----------|
+| 0    | mono     | 44100       | 128k    | Slightly oversized files |
+| 1    | mono     | 32000       | 96k     | Moderate reduction |
+| 2    | mono     | 22050       | 64k     | Previous hardcoded behavior |
+| 3    | mono     | 16000       | 48k     | Long episodes |
+| 4    | mono     | 16000       | 32k     | Last resort |
+
+All tiers use mono — Whisper processes mono internally, so stereo doubles size for zero benefit.
+
+### Fallback behavior
+
+- `episode.duration is None` → use tier 4 (most aggressive, safe default)
+- No tier fits the estimate → still attempt tier 4; the post-resize size check catches actual failures
+
+## Changes
+
+### `episodes/transcriber.py`
+
+1. Add `RESIZE_TIERS` tuple constant and `RESIZE_SAFETY_MARGIN = 1.10` after `FFMPEG_TIMEOUT`
+2. Add `_select_resize_tier(duration_seconds, max_size_bytes)` — pure function, returns tier index or `None`
+3. Update `_resize_if_needed` to call `_select_resize_tier` and build ffmpeg args from the selected tier instead of hardcoded values
+4. Add info-level logging of which tier was selected
+
+### `episodes/tests/test_transcribe.py`
+
+1. New `ResizeTierSelectionTests` class — pure unit tests for `_select_resize_tier`
+2. New tests in `ResizeWithinTranscribeTests` for duration-based tier selection and `None` duration fallback
+3. Existing tests pass unchanged — they don't set `duration`, so they fall back to tier 4

--- a/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md
+++ b/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md
@@ -1,0 +1,33 @@
+# Session: Adaptive Audio Resize Tiers — Implementation
+
+**Session ID:** 124bb45c-1851-4ccb-a20f-9289b26938d3
+**Date:** 2026-03-15
+
+## Summary
+
+Implemented adaptive tier selection for audio resize in `episodes/transcriber.py`, replacing hardcoded ffmpeg settings with duration-based tier selection. Added unit and integration tests.
+
+## Conversation
+
+### User
+Provided the accepted plan and asked to implement it.
+
+### Assistant
+Read `episodes/transcriber.py` and `episodes/tests/test_transcribe.py` to understand the current code.
+
+Added to `transcriber.py`:
+1. `RESIZE_TIERS` — tuple of 5 tiers from (mono/44100/128k) to (mono/16000/32k)
+2. `RESIZE_SAFETY_MARGIN = 1.10`
+3. `_select_resize_tier(duration_seconds, max_size_bytes)` — iterates tiers, picks first whose estimated size fits; returns `None` if none fit, returns last tier if duration is `None`
+4. Updated `_resize_if_needed` to call `_select_resize_tier`, build ffmpeg args from the selected tier, and log the selection at info level
+
+Added to `test_transcribe.py`:
+1. `ResizeTierSelectionTests` — 4 pure unit tests covering short/medium/very long episodes and `None` duration
+2. Two integration tests in `ResizeWithinTranscribeTests`: `test_duration_selects_gentle_tier` (600s → 128k) and `test_no_duration_uses_most_aggressive` (no duration → 32k)
+
+First test run: 1 failure — `test_duration_selects_gentle_tier` used `RAGTIME_MAX_AUDIO_SIZE=50` (bytes), making all tier estimates far too large. Fixed by using realistic `25 * 1024 * 1024` max size and `26 * 1024 * 1024` audio size for that test.
+
+Second run: all 18 tests passed.
+
+### User
+Confirmed local testing works, asked to create a PR.

--- a/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md
+++ b/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md
@@ -31,3 +31,33 @@ Second run: all 18 tests passed.
 
 ### User
 Confirmed local testing works, asked to create a PR.
+
+### Assistant
+Created branch `feature/adaptive-audio-resize-tiers`, committed all changes (code, plan, feature doc, session transcripts, changelog), pushed and opened PR #46.
+
+### User
+Asked to update the README Transcribe section to mention adaptive downsampling.
+
+### Assistant
+Updated the `#### 4. Transcribe` section in `README.md` — rephrased to lead with the Whisper API, then describe the configurable size limit and adaptive downsampling with a link to the feature doc. Committed and pushed.
+
+### User
+Asked to check PR review comments.
+
+### Assistant
+Fetched 4 Copilot review comments:
+1. Retry with lower tiers when actual output exceeds the limit
+2. Test allocates 26MB in memory unnecessarily
+3. Duplicate bitrate representation (`"128k"` and `128_000`)
+4. Unknown-duration fallback (32k) doesn't match old hardcoded behavior (64k)
+
+### User
+Asked to implement fixes for comments 1–3. For comment 4, go with option (b): keep tier 4 as fallback and update the PR description.
+
+### Assistant
+Applied three fixes:
+1. **Retry loop** — `_resize_if_needed` now iterates from the selected tier through progressively more aggressive tiers until the output fits or all tiers are exhausted. Added `test_retry_with_lower_tier_on_oversize`.
+2. **Shrink test allocation** — replaced 26MB `ContentFile` with 200 bytes and `RAGTIME_MAX_AUDIO_SIZE=100`, using a tiny duration so tier 0 is still selected.
+3. **Deduplicate bitrate** — `RESIZE_TIERS` now stores `bitrate_kbps` as a single int; the ffmpeg string is derived via `f"{bitrate_kbps}k"` and the bps for estimation via `bitrate_kbps * 1000`.
+
+Updated PR description to clarify that the unknown-duration fallback (32k) is intentionally more conservative than the old 64k. Replied to all 4 review comments. All 19 tests pass.

--- a/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md
+++ b/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md
@@ -1,0 +1,25 @@
+# Session: Adaptive Audio Resize Tiers — Planning
+
+**Session ID:** f750c0ab-7ee3-4e9b-81ff-9bebac97db25
+**Date:** 2026-03-15
+
+## Summary
+
+Planned adaptive tier selection for the audio resize step, so that slightly oversized files get gentler compression instead of always applying the most aggressive ffmpeg settings.
+
+## Conversation
+
+### User
+Requested planning for adaptive audio resize tiers — the current `_resize_if_needed` always applies mono/22050Hz/64kbps regardless of how much reduction is needed.
+
+### Assistant
+Explored `episodes/transcriber.py` to understand the current resize logic. Noted that `episode.duration` (added in the episode-duration feature) is available and can be used to estimate the minimum bitrate needed. Considered approaches:
+
+- **Rejected:** Binary search on ffmpeg settings — too slow (multiple ffmpeg invocations).
+- **Rejected:** Single formula for bitrate — doesn't account for discrete sample rate/channel options.
+- **Chosen:** Tiered approach — 5 preset quality tiers, pick the first whose estimated output fits under the size limit.
+
+Designed the tier table (128k down to 32k), all mono since Whisper processes mono internally. Added a 10% safety margin for MP3 container overhead. Defined fallback behavior: `None` duration → most aggressive tier, no tier fits → attempt most aggressive anyway.
+
+### User
+Approved the plan.

--- a/episodes/tests/test_transcribe.py
+++ b/episodes/tests/test_transcribe.py
@@ -251,13 +251,13 @@ class ResizeWithinTranscribeTests(TestCase):
     @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
     @override_settings(RAGTIME_MAX_AUDIO_SIZE=50)
     def test_still_too_large_after_resize(self, mock_which, mock_run, mock_factory):
-        """Resized file still over max → status failed."""
+        """Resized file still over max after all tiers → status failed."""
         from episodes.transcriber import transcribe_episode
 
         def fake_ffmpeg(args, **kw):
             output_path = args[-1]
             with open(output_path, "wb") as f:
-                f.write(b"x" * 200)  # still too large
+                f.write(b"x" * 200)  # still too large for every tier
             return MagicMock(returncode=0)
 
         mock_run.side_effect = fake_ffmpeg
@@ -323,7 +323,7 @@ class ResizeWithinTranscribeTests(TestCase):
     @patch("episodes.transcriber.get_transcription_provider")
     @patch("episodes.transcriber.subprocess.run")
     @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
-    @override_settings(RAGTIME_MAX_AUDIO_SIZE=25 * 1024 * 1024)
+    @override_settings(RAGTIME_MAX_AUDIO_SIZE=100)
     def test_duration_selects_gentle_tier(self, mock_which, mock_run, mock_factory):
         """Episode with short duration selects high-quality tier."""
         from episodes.transcriber import transcribe_episode
@@ -335,16 +335,16 @@ class ResizeWithinTranscribeTests(TestCase):
         def fake_ffmpeg(args, **kw):
             output_path = args[-1]
             with open(output_path, "wb") as f:
-                f.write(b"x" * 100)  # small enough
+                f.write(b"x" * 50)  # under 100 limit
             return MagicMock(returncode=0)
 
         mock_run.side_effect = fake_ffmpeg
 
         episode = self._create_episode_with_audio(
-            audio_size=26 * 1024 * 1024,
+            audio_size=200,
             url="https://example.com/ep/rtr-6",
             status=Episode.Status.TRANSCRIBING,
-            duration=600,  # 10 minutes — should pick tier 0 (128k)
+            duration=0.0005,  # tiny duration — tier 0 estimate fits under 100 bytes
         )
 
         with patch("episodes.signals.async_task"):
@@ -355,6 +355,48 @@ class ResizeWithinTranscribeTests(TestCase):
         ffmpeg_args = mock_run.call_args[0][0]
         self.assertIn("128k", ffmpeg_args)
         self.assertIn("44100", ffmpeg_args)
+
+    @patch("episodes.transcriber.get_transcription_provider")
+    @patch("episodes.transcriber.subprocess.run")
+    @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
+    @override_settings(RAGTIME_MAX_AUDIO_SIZE=100)
+    def test_retry_with_lower_tier_on_oversize(self, mock_which, mock_run, mock_factory):
+        """First tier output too large → retries with next tier until it fits."""
+        from episodes.transcriber import transcribe_episode
+
+        mock_provider = MagicMock()
+        mock_provider.transcribe.return_value = SAMPLE_WHISPER_RESPONSE
+        mock_factory.return_value = mock_provider
+
+        call_count = 0
+
+        def fake_ffmpeg(args, **kw):
+            nonlocal call_count
+            call_count += 1
+            output_path = args[-1]
+            with open(output_path, "wb") as f:
+                # First call: still too large; second call: fits
+                f.write(b"x" * (200 if call_count == 1 else 50))
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_ffmpeg
+
+        episode = self._create_episode_with_audio(
+            audio_size=200,
+            url="https://example.com/ep/rtr-8",
+            status=Episode.Status.TRANSCRIBING,
+            duration=0.0005,  # tiny duration — starts at tier 0
+        )
+
+        with patch("episodes.signals.async_task"):
+            transcribe_episode(episode.pk)
+
+        episode.refresh_from_db()
+        self.assertEqual(episode.status, Episode.Status.SUMMARIZING)
+        self.assertEqual(mock_run.call_count, 2)
+        # Second call should use tier 1 (96k)
+        second_call_args = mock_run.call_args_list[1][0][0]
+        self.assertIn("96k", second_call_args)
 
     @patch("episodes.transcriber.get_transcription_provider")
     @patch("episodes.transcriber.subprocess.run")

--- a/episodes/tests/test_transcribe.py
+++ b/episodes/tests/test_transcribe.py
@@ -319,3 +319,109 @@ class ResizeWithinTranscribeTests(TestCase):
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.FAILED)
         self.assertIn("ffmpeg failed", episode.error_message)
+
+    @patch("episodes.transcriber.get_transcription_provider")
+    @patch("episodes.transcriber.subprocess.run")
+    @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
+    @override_settings(RAGTIME_MAX_AUDIO_SIZE=25 * 1024 * 1024)
+    def test_duration_selects_gentle_tier(self, mock_which, mock_run, mock_factory):
+        """Episode with short duration selects high-quality tier."""
+        from episodes.transcriber import transcribe_episode
+
+        mock_provider = MagicMock()
+        mock_provider.transcribe.return_value = SAMPLE_WHISPER_RESPONSE
+        mock_factory.return_value = mock_provider
+
+        def fake_ffmpeg(args, **kw):
+            output_path = args[-1]
+            with open(output_path, "wb") as f:
+                f.write(b"x" * 100)  # small enough
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_ffmpeg
+
+        episode = self._create_episode_with_audio(
+            audio_size=26 * 1024 * 1024,
+            url="https://example.com/ep/rtr-6",
+            status=Episode.Status.TRANSCRIBING,
+            duration=600,  # 10 minutes — should pick tier 0 (128k)
+        )
+
+        with patch("episodes.signals.async_task"):
+            transcribe_episode(episode.pk)
+
+        episode.refresh_from_db()
+        self.assertEqual(episode.status, Episode.Status.SUMMARIZING)
+        ffmpeg_args = mock_run.call_args[0][0]
+        self.assertIn("128k", ffmpeg_args)
+        self.assertIn("44100", ffmpeg_args)
+
+    @patch("episodes.transcriber.get_transcription_provider")
+    @patch("episodes.transcriber.subprocess.run")
+    @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
+    @override_settings(RAGTIME_MAX_AUDIO_SIZE=50)
+    def test_no_duration_uses_most_aggressive(self, mock_which, mock_run, mock_factory):
+        """Episode without duration falls back to tier 4 (32k)."""
+        from episodes.transcriber import transcribe_episode
+
+        mock_provider = MagicMock()
+        mock_provider.transcribe.return_value = SAMPLE_WHISPER_RESPONSE
+        mock_factory.return_value = mock_provider
+
+        def fake_ffmpeg(args, **kw):
+            output_path = args[-1]
+            with open(output_path, "wb") as f:
+                f.write(b"small" * 5)
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_ffmpeg
+
+        episode = self._create_episode_with_audio(
+            audio_size=200,
+            url="https://example.com/ep/rtr-7",
+            status=Episode.Status.TRANSCRIBING,
+            # no duration set
+        )
+
+        with patch("episodes.signals.async_task"):
+            transcribe_episode(episode.pk)
+
+        episode.refresh_from_db()
+        self.assertEqual(episode.status, Episode.Status.SUMMARIZING)
+        ffmpeg_args = mock_run.call_args[0][0]
+        self.assertIn("32k", ffmpeg_args)
+        self.assertIn("16000", ffmpeg_args)
+
+
+class ResizeTierSelectionTests(TestCase):
+    """Pure unit tests for _select_resize_tier."""
+
+    def test_short_episode_picks_tier_0(self):
+        from episodes.transcriber import _select_resize_tier
+
+        # 600s at 128kbps * 1.10 = ~10.56MB, well under 25MB
+        max_size = 25 * 1024 * 1024
+        self.assertEqual(_select_resize_tier(600, max_size), 0)
+
+    def test_medium_episode_picks_lower_tier(self):
+        from episodes.transcriber import _select_resize_tier
+
+        # 3600s at 128kbps * 1.10 = ~63.4MB > 25MB → not tier 0
+        # 3600s at 96kbps * 1.10 = ~47.5MB > 25MB → not tier 1
+        # 3600s at 64kbps * 1.10 = ~31.7MB > 25MB → not tier 2
+        # 3600s at 48kbps * 1.10 = ~23.8MB < 25MB → tier 3
+        max_size = 25 * 1024 * 1024
+        self.assertEqual(_select_resize_tier(3600, max_size), 3)
+
+    def test_very_long_episode_returns_none(self):
+        from episodes.transcriber import _select_resize_tier
+
+        # 20000s at 32kbps * 1.10 = ~88MB > 25MB → no tier fits
+        max_size = 25 * 1024 * 1024
+        self.assertIsNone(_select_resize_tier(20000, max_size))
+
+    def test_none_duration_returns_last_tier(self):
+        from episodes.transcriber import _select_resize_tier
+
+        max_size = 25 * 1024 * 1024
+        self.assertEqual(_select_resize_tier(None, max_size), 4)

--- a/episodes/tests/test_transcribe.py
+++ b/episodes/tests/test_transcribe.py
@@ -323,9 +323,9 @@ class ResizeWithinTranscribeTests(TestCase):
     @patch("episodes.transcriber.get_transcription_provider")
     @patch("episodes.transcriber.subprocess.run")
     @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
-    @override_settings(RAGTIME_MAX_AUDIO_SIZE=100)
+    @override_settings(RAGTIME_MAX_AUDIO_SIZE=200_000)
     def test_duration_selects_gentle_tier(self, mock_which, mock_run, mock_factory):
-        """Episode with short duration selects high-quality tier."""
+        """Episode with short duration selects high-quality tier (128k)."""
         from episodes.transcriber import transcribe_episode
 
         mock_provider = MagicMock()
@@ -335,16 +335,17 @@ class ResizeWithinTranscribeTests(TestCase):
         def fake_ffmpeg(args, **kw):
             output_path = args[-1]
             with open(output_path, "wb") as f:
-                f.write(b"x" * 50)  # under 100 limit
+                f.write(b"x" * 100)
             return MagicMock(returncode=0)
 
         mock_run.side_effect = fake_ffmpeg
 
+        # 10s at 128kbps * 1.10 = 176,000 bytes, under 200,000 limit → tier 0
         episode = self._create_episode_with_audio(
-            audio_size=200,
+            audio_size=300_000,
             url="https://example.com/ep/rtr-6",
             status=Episode.Status.TRANSCRIBING,
-            duration=0.0005,  # tiny duration — tier 0 estimate fits under 100 bytes
+            duration=10,
         )
 
         with patch("episodes.signals.async_task"):
@@ -359,7 +360,7 @@ class ResizeWithinTranscribeTests(TestCase):
     @patch("episodes.transcriber.get_transcription_provider")
     @patch("episodes.transcriber.subprocess.run")
     @patch("episodes.transcriber.shutil.which", return_value="/usr/bin/ffmpeg")
-    @override_settings(RAGTIME_MAX_AUDIO_SIZE=100)
+    @override_settings(RAGTIME_MAX_AUDIO_SIZE=200_000)
     def test_retry_with_lower_tier_on_oversize(self, mock_which, mock_run, mock_factory):
         """First tier output too large → retries with next tier until it fits."""
         from episodes.transcriber import transcribe_episode
@@ -376,16 +377,17 @@ class ResizeWithinTranscribeTests(TestCase):
             output_path = args[-1]
             with open(output_path, "wb") as f:
                 # First call: still too large; second call: fits
-                f.write(b"x" * (200 if call_count == 1 else 50))
+                f.write(b"x" * (300_000 if call_count == 1 else 100))
             return MagicMock(returncode=0)
 
         mock_run.side_effect = fake_ffmpeg
 
+        # 10s at 128kbps * 1.10 = 176,000 bytes → starts at tier 0
         episode = self._create_episode_with_audio(
-            audio_size=200,
+            audio_size=300_000,
             url="https://example.com/ep/rtr-8",
             status=Episode.Status.TRANSCRIBING,
-            duration=0.0005,  # tiny duration — starts at tier 0
+            duration=10,
         )
 
         with patch("episodes.signals.async_task"):

--- a/episodes/transcriber.py
+++ b/episodes/transcriber.py
@@ -32,6 +32,7 @@ def _select_resize_tier(duration_seconds, max_size_bytes):
     """Pick the gentlest resize tier whose estimated output fits under max_size_bytes.
 
     Returns the tier index (into RESIZE_TIERS) or None if no tier fits.
+    If duration_seconds is None, returns the last (most aggressive) tier.
     """
     if duration_seconds is None:
         return len(RESIZE_TIERS) - 1
@@ -83,6 +84,7 @@ def _resize_if_needed(episode):
                 result = subprocess.run(
                     [
                         "ffmpeg",
+                        "-hide_banner", "-loglevel", "error",
                         "-i", input_path,
                         "-ac", str(channels),
                         "-ar", str(sample_rate),

--- a/episodes/transcriber.py
+++ b/episodes/transcriber.py
@@ -15,6 +15,34 @@ logger = logging.getLogger(__name__)
 
 FFMPEG_TIMEOUT = 300  # 5 minutes — must fit within Q_CLUSTER['timeout']
 
+# Tiers ordered from highest to lowest quality.
+# Each tuple: (channels, sample_rate, bitrate_str, bitrate_bps)
+RESIZE_TIERS = (
+    (1, 44100, "128k", 128_000),
+    (1, 32000, "96k", 96_000),
+    (1, 22050, "64k", 64_000),
+    (1, 16000, "48k", 48_000),
+    (1, 16000, "32k", 32_000),
+)
+
+RESIZE_SAFETY_MARGIN = 1.10  # 10% overhead for MP3 container/framing
+
+
+def _select_resize_tier(duration_seconds, max_size_bytes):
+    """Pick the gentlest resize tier whose estimated output fits under max_size_bytes.
+
+    Returns the tier index (into RESIZE_TIERS) or None if no tier fits.
+    """
+    if duration_seconds is None:
+        return len(RESIZE_TIERS) - 1
+
+    for i, (_channels, _sr, _br_str, bitrate_bps) in enumerate(RESIZE_TIERS):
+        estimated = (bitrate_bps / 8) * duration_seconds * RESIZE_SAFETY_MARGIN
+        if estimated <= max_size_bytes:
+            return i
+
+    return None
+
 
 def _resize_if_needed(episode):
     """Downsample audio with ffmpeg if it exceeds the max file size.
@@ -28,6 +56,19 @@ def _resize_if_needed(episode):
     if not shutil.which("ffmpeg"):
         raise RuntimeError("ffmpeg is not installed or not on PATH")
 
+    tier_idx = _select_resize_tier(
+        getattr(episode, "duration", None), max_size
+    )
+    if tier_idx is None:
+        # No tier fits the estimate — try the most aggressive as last resort.
+        tier_idx = len(RESIZE_TIERS) - 1
+
+    channels, sample_rate, bitrate_str, _ = RESIZE_TIERS[tier_idx]
+    logger.info(
+        "Episode %s: resize tier %d selected (ac=%d ar=%d b:a=%s)",
+        episode.pk, tier_idx, channels, sample_rate, bitrate_str,
+    )
+
     input_path = episode.audio_file.path
     output_path = None
 
@@ -40,9 +81,9 @@ def _resize_if_needed(episode):
                 [
                     "ffmpeg",
                     "-i", input_path,
-                    "-ac", "1",
-                    "-ar", "22050",
-                    "-b:a", "64k",
+                    "-ac", str(channels),
+                    "-ar", str(sample_rate),
+                    "-b:a", bitrate_str,
                     "-y",
                     output_path,
                 ],

--- a/episodes/transcriber.py
+++ b/episodes/transcriber.py
@@ -16,13 +16,13 @@ logger = logging.getLogger(__name__)
 FFMPEG_TIMEOUT = 300  # 5 minutes — must fit within Q_CLUSTER['timeout']
 
 # Tiers ordered from highest to lowest quality.
-# Each tuple: (channels, sample_rate, bitrate_str, bitrate_bps)
+# Each tuple: (channels, sample_rate, bitrate_kbps)
 RESIZE_TIERS = (
-    (1, 44100, "128k", 128_000),
-    (1, 32000, "96k", 96_000),
-    (1, 22050, "64k", 64_000),
-    (1, 16000, "48k", 48_000),
-    (1, 16000, "32k", 32_000),
+    (1, 44100, 128),
+    (1, 32000, 96),
+    (1, 22050, 64),
+    (1, 16000, 48),
+    (1, 16000, 32),
 )
 
 RESIZE_SAFETY_MARGIN = 1.10  # 10% overhead for MP3 container/framing
@@ -36,8 +36,8 @@ def _select_resize_tier(duration_seconds, max_size_bytes):
     if duration_seconds is None:
         return len(RESIZE_TIERS) - 1
 
-    for i, (_channels, _sr, _br_str, bitrate_bps) in enumerate(RESIZE_TIERS):
-        estimated = (bitrate_bps / 8) * duration_seconds * RESIZE_SAFETY_MARGIN
+    for i, (_channels, _sr, bitrate_kbps) in enumerate(RESIZE_TIERS):
+        estimated = (bitrate_kbps * 1000 / 8) * duration_seconds * RESIZE_SAFETY_MARGIN
         if estimated <= max_size_bytes:
             return i
 
@@ -63,12 +63,6 @@ def _resize_if_needed(episode):
         # No tier fits the estimate — try the most aggressive as last resort.
         tier_idx = len(RESIZE_TIERS) - 1
 
-    channels, sample_rate, bitrate_str, _ = RESIZE_TIERS[tier_idx]
-    logger.info(
-        "Episode %s: resize tier %d selected (ac=%d ar=%d b:a=%s)",
-        episode.pk, tier_idx, channels, sample_rate, bitrate_str,
-    )
-
     input_path = episode.audio_file.path
     output_path = None
 
@@ -76,37 +70,53 @@ def _resize_if_needed(episode):
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp:
             output_path = tmp.name
 
-        try:
-            result = subprocess.run(
-                [
-                    "ffmpeg",
-                    "-i", input_path,
-                    "-ac", str(channels),
-                    "-ar", str(sample_rate),
-                    "-b:a", bitrate_str,
-                    "-y",
-                    output_path,
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                timeout=FFMPEG_TIMEOUT,
-            )
-        except subprocess.TimeoutExpired:
-            raise RuntimeError(
-                f"ffmpeg timed out during audio resize ({FFMPEG_TIMEOUT}s)"
+        # Try selected tier, then progressively more aggressive tiers.
+        for idx in range(tier_idx, len(RESIZE_TIERS)):
+            channels, sample_rate, bitrate_kbps = RESIZE_TIERS[idx]
+            bitrate_str = f"{bitrate_kbps}k"
+            logger.info(
+                "Episode %s: trying resize tier %d (ac=%d ar=%d b:a=%s)",
+                episode.pk, idx, channels, sample_rate, bitrate_str,
             )
 
-        if result.returncode != 0:
-            stderr = result.stderr.decode(errors="replace")
-            raise RuntimeError(
-                f"ffmpeg failed (exit {result.returncode}): {stderr[:500]}"
-            )
+            try:
+                result = subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-i", input_path,
+                        "-ac", str(channels),
+                        "-ar", str(sample_rate),
+                        "-b:a", bitrate_str,
+                        "-y",
+                        output_path,
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    timeout=FFMPEG_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                raise RuntimeError(
+                    f"ffmpeg timed out during audio resize ({FFMPEG_TIMEOUT}s)"
+                )
 
-        output_size = os.path.getsize(output_path)
-        if output_size > max_size:
+            if result.returncode != 0:
+                stderr = result.stderr.decode(errors="replace")
+                raise RuntimeError(
+                    f"ffmpeg failed (exit {result.returncode}): {stderr[:500]}"
+                )
+
+            output_size = os.path.getsize(output_path)
+            if output_size <= max_size:
+                break
+
+            logger.info(
+                "Episode %s: tier %d output %.1fMB still exceeds limit, trying next tier",
+                episode.pk, idx, output_size / (1024 * 1024),
+            )
+        else:
             raise RuntimeError(
                 f"Audio file exceeds {max_size / (1024 * 1024):.1f}MB limit after resizing "
-                f"({output_size / (1024 * 1024):.1f}MB)"
+                f"with all tiers ({output_size / (1024 * 1024):.1f}MB)"
             )
 
         filename = f"{episode.pk}.mp3"


### PR DESCRIPTION
## Summary

- Replace hardcoded ffmpeg settings (mono/22kHz/64kbps) with 5 quality tiers selected based on episode duration
- Short episodes get gentler compression (128kbps), long episodes get more aggressive settings (32kbps)
- Falls back to most aggressive tier when duration is unknown (more conservative than the old hardcoded 64kbps)
- Retries with progressively more aggressive tiers if the actual output still exceeds the size limit

## Tiers

| Tier | Sample Rate | Bitrate | Use case |
|------|-------------|---------|----------|
| 0    | 44100       | 128k    | Slightly oversized files |
| 1    | 32000       | 96k     | Moderate reduction |
| 2    | 22050       | 64k     | Previous hardcoded behavior |
| 3    | 16000       | 48k     | Long episodes |
| 4    | 16000       | 32k     | Last resort / unknown duration |

## Test plan

- [x] All 19 existing + new transcribe tests pass
- [ ] Verify with a real slightly-oversized file that tier 0 is selected
- [ ] Verify with a long episode that a lower tier is selected

## Docs

- [Plan](doc/plans/adaptive-audio-resize-tiers.md)
- [Feature](doc/features/adaptive-audio-resize-tiers.md)
- [Planning session](doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md)
- [Implementation session](doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)