### PR TITLE
Chunk-level entity extraction and resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Adaptive Audio Resize Tiers — select the gentlest ffmpeg settings that fit under the Whisper API size limit based on episode duration, instead of always using the most aggressive compression — [plan](doc/plans/adaptive-audio-resize-tiers.md), [feature](doc/features/adaptive-audio-resize-tiers.md), [planning session](doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md), [implementation session](doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md)
 
+- Chunk-level Entity Extraction — extract entities per chunk instead of per episode, linking each entity mention to the specific chunk (and timestamp) where it appeared. Resolution aggregates unique names across chunks before resolving — [plan](doc/plans/chunk-level-entity-extraction.md), [feature](doc/features/chunk-level-entity-extraction.md), [planning session](doc/sessions/2026-03-15-chunk-level-entity-extraction-planning-session.md), [implementation session](doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md)
+
 ### Changed
 
 - Merge Resize into Transcribe — absorb ffmpeg downsampling into the transcribe step, reducing the pipeline from 11 to 10 steps. Resize was a transcription provider implementation detail, not a meaningful domain event — [plan](doc/plans/merge-resize-into-transcribe.md), [feature](doc/features/merge-resize-into-transcribe.md), [planning session](doc/sessions/2026-03-15-merge-resize-into-transcribe-planning-session.md), [implementation session](doc/sessions/2026-03-15-merge-resize-into-transcribe-implementation-session.md)

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Split transcript into ~150-word chunks along Whisper segment boundaries, with 1-
 
 #### 7. 🔍 Extract (status: `extracting`)
 
-LLM-based entity extraction from the transcript. Entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) are stored in the database and managed via Django admin. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with `uv run python manage.py load_entity_types`. New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity).
+LLM-based entity extraction runs **per chunk**, linking each entity mention to the specific chunk (and thus timestamp) where it appeared. Entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) are stored in the database and managed via Django admin. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with `uv run python manage.py load_entity_types`. New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity). Raw extraction results are stored in `Chunk.entities_json`.
 
 #### 8. 🧩 Resolve (status: `resolving`)
 
-Match extracted entities against existing DB records using LLM-based fuzzy matching to prevent duplicates. Creates canonical entity records and links them to episodes.
+Aggregates unique entity names across all chunks, then resolves once per entity type against existing DB records using LLM-based fuzzy matching to prevent duplicates. Creates canonical entity records and `EntityMention` records per (entity, chunk) pair, preserving provenance.
 
 #### 9. 📐 Embed (status: `embedding`)
 

--- a/doc/features/chunk-level-entity-extraction.md
+++ b/doc/features/chunk-level-entity-extraction.md
@@ -1,0 +1,24 @@
+# Chunk-level Entity Extraction & Resolution
+
+## Problem
+
+Entity extraction ran on the full episode transcript as one LLM call, storing results in `episode.entities_json`. Entity mentions were linked only to episodes, with no provenance about *where* in the episode an entity appeared. Since chunks already have timestamps, extracting per-chunk gives us positional context for free.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `episodes/models.py` | Added `Chunk.entities_json` (JSONField); added `EntityMention.chunk` FK; replaced unique constraint from `(entity, episode, context)` to `(entity, chunk)` |
+| `episodes/migrations/0016_chunk_level_extraction.py` | Multi-step migration: add fields, delete existing mentions, make chunk non-nullable, swap constraints |
+| `episodes/extractor.py` | Validate chunks exist (not transcript); loop over chunks calling provider per chunk; store in `chunk.entities_json`; bulk_update; updated system prompt to say "transcript excerpt" |
+| `episodes/resolver.py` | Aggregate entities from `chunk.entities_json` across all chunks; resolve unique names per type; create `EntityMention` per (entity, chunk) pair; treat "no entities" as success |
+| `episodes/admin.py` | Added `chunk` to readonly fields on `EntityMentionInlineForEpisode`, `EntityMentionInlineForEntity`, and `EntityMentionAdmin` |
+| `episodes/tests/test_extract.py` | Tests create chunks; verify `chunk.entities_json` populated; N chunks → N LLM calls; "no chunks" → failure |
+| `episodes/tests/test_resolve.py` | Tests use chunks with `entities_json`; verify chunk FKs on mentions; test same entity in multiple chunks → multiple mentions; test aggregation (one resolution call) |
+| `README.md` | Updated Extract and Resolve step descriptions |
+
+## Verification
+
+1. `uv run python manage.py migrate` — applies cleanly
+2. `uv run python manage.py test episodes` — all 102 tests pass
+3. Admin: EntityMention inlines and list view show chunk column

--- a/doc/plans/chunk-level-entity-extraction.md
+++ b/doc/plans/chunk-level-entity-extraction.md
@@ -1,0 +1,56 @@
+# Chunk-level Entity Extraction & Resolution
+
+## Context
+
+The pipeline currently runs extraction on the full `episode.transcript` and stores results in `episode.entities_json`. Resolution then creates `EntityMention` records linked to episodes. Since chunking now runs **before** extraction, we can extract per-chunk, linking each entity mention to the specific chunk (and thus timestamp) where it appeared.
+
+## Approach
+
+- **Extraction** runs per-chunk (one LLM call per chunk).
+- **Resolution** aggregates unique entity names across all chunks, then resolves once per entity type against the DB (same LLM call count as today for resolution).
+- **EntityMention** records are created per (entity, chunk) pair.
+
+### Flow
+
+```
+chunks ──► extract per chunk ──► aggregate unique names ──► resolve per type ──► create mentions per chunk
+```
+
+## Model Changes
+
+| Model | Change |
+|-------|--------|
+| `Chunk` | Add `entities_json = JSONField(blank=True, null=True)` |
+| `EntityMention` | Add `chunk = ForeignKey(Chunk, CASCADE)`, replace unique constraint `(entity, episode, context)` with `(entity, chunk)` |
+| `Episode.entities_json` | Stop writing to it; keep field for now |
+
+## Migration Strategy
+
+1. Add `Chunk.entities_json`
+2. Add `EntityMention.chunk` (nullable initially)
+3. Data migration: delete all existing EntityMention rows
+4. Make `EntityMention.chunk` non-nullable
+5. Drop old unique constraint, add new `(entity, chunk)`
+
+## Extractor Changes
+
+- Validate chunks exist (instead of `episode.transcript`)
+- Loop over chunks, call provider per chunk
+- Store result in `chunk.entities_json`
+- `bulk_update` all chunks
+
+## Resolver Changes
+
+- **Phase A — Aggregate:** Collect `{type_key: {name: [(chunk, context), ...]}}` across all chunks
+- **Phase B — Resolve:** For each entity type, same logic as today with unique names
+- **Phase C — Create mentions:** `EntityMention(entity=..., episode=..., chunk=..., context=...)` per (name, chunk, context) triple
+- Handle "no entities in any chunk" as success (not failure)
+
+## Trade-offs
+
+| | Episode-level (current) | Chunk-level (proposed) |
+|---|---|---|
+| **LLM calls** | 1 per episode | ~40-60 per episode |
+| **Entity provenance** | None | Chunk + timestamp |
+| **RAG alignment** | Disconnected | Shared unit |
+| **Cost** | Lower | Higher, but inputs are small |

--- a/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
+++ b/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
@@ -45,3 +45,57 @@ Read all critical files: `episodes/models.py`, `episodes/extractor.py`, `episode
 **README:** Updated Extract and Resolve step descriptions.
 
 All 102 tests pass. Migration applies cleanly. No pending migrations.
+
+### User
+Requested clickable Episode link in EntityMention admin list view.
+
+### Assistant
+Added `episode_link` method using `reverse("admin:episodes_episode_change", ...)` to `EntityMentionAdmin`, replacing the plain `episode` column.
+
+### User
+Asked whether Chunks should be exposed in Django admin.
+
+### Assistant
+Proposed registering a read-only `ChunkAdmin` with entity mention inline, plus clickable chunk links in `EntityMentionAdmin`. User approved.
+
+### Assistant
+- Registered `ChunkAdmin` with `episode_link`, `formatted_time_range`, `short_text`, `has_entities` columns
+- Added `EntityMentionInlineForChunk` (excludes episode column since it's on the parent page)
+- Added `chunk_link` to `EntityMentionAdmin` list view
+- Added `show_change_link = True` to `ChunkInlineForEpisode`
+
+### User
+Noted that Entity Mentions inline on Chunk detail should not show Episode column.
+
+### Assistant
+Set explicit `fields` on `EntityMentionInlineForChunk` to show only `entity`, `context`, `created_at`.
+
+### User
+Requested PR creation.
+
+### Assistant
+Created PR #47: https://github.com/rafacm/ragtime/pull/47
+
+### PR Review — Copilot (5 comments)
+
+**Comment 1 — Silent context loss with `ignore_conflicts` (`resolver.py:139-150`):**
+`bulk_create(ignore_conflicts=True)` silently drops duplicate `(entity, chunk)` pairs; if the extractor returns the same name twice in a chunk with different contexts, one is lost.
+**Fix:** De-duplicated by `(name, chunk)` in `_aggregate_entities_from_chunks()` (keeps first context per chunk). Removed `ignore_conflicts=True` from both `bulk_create` call sites.
+
+**Comment 2 — High-cardinality `list_filter` (`admin.py:274`):**
+`list_filter = ("episode__title",)` creates one sidebar entry per unique title.
+**Fix:** Changed to `list_filter = ("episode",)` for FK filter widget.
+
+**Comment 3 — Redundant inner import (`extractor.py:121-122`):**
+`from .models import Chunk` inside function body when module already imports from `.models`.
+**Fix:** Added `Chunk` to top-level import, removed inner import.
+
+**Comment 4 — Missing mention cleanup in early-return path (`resolver.py:103-105`):**
+When no chunks/entities exist, stale `EntityMention` rows from a previous run survive.
+**Fix:** Added `EntityMention.objects.filter(episode=episode).delete()` before early return.
+
+**Comment 5 — Per-name DB round-trips (`resolver.py:127-138`):**
+One `Entity.objects.create()` + one `bulk_create()` per name.
+**Fix:** Batched all `EntityMention` objects per entity type into a single `bulk_create`. `Entity.objects.create()` per name kept because SQLite doesn't support `bulk_create` returning IDs.
+
+All 102 tests pass after fixes.

--- a/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
+++ b/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
@@ -1,0 +1,47 @@
+# Session: Chunk-level Entity Extraction — Implementation
+
+**Session ID:** (current session)
+**Date:** 2026-03-15
+
+## Summary
+
+Implemented chunk-level entity extraction and resolution, linking each entity mention to the specific chunk where it appeared.
+
+## Conversation
+
+### User
+Provided the accepted plan for chunk-level entity extraction and asked to implement it.
+
+### Assistant
+Read all critical files: `episodes/models.py`, `episodes/extractor.py`, `episodes/resolver.py`, `episodes/admin.py`, and both test files.
+
+**Model changes (`episodes/models.py`):**
+- Added `entities_json = JSONField(blank=True, null=True)` to `Chunk`
+- Added `chunk = ForeignKey("Chunk", CASCADE, related_name="entity_mentions")` to `EntityMention`
+- Replaced unique constraint from `(entity, episode, context)` to `(entity, chunk)`
+
+**Migration (`0016_chunk_level_extraction.py`):**
+- Wrote a multi-step migration: add `Chunk.entities_json`, add `EntityMention.chunk` as nullable, data migration to delete all existing mentions, make chunk non-nullable, swap constraints. Chose manual migration over auto-generated because Django can't auto-create a non-nullable FK without a default.
+
+**Extractor changes (`episodes/extractor.py`):**
+- Changed validation from checking `episode.transcript` to checking for chunks
+- Added loop over chunks, calling `provider.structured_extract` per chunk with `chunk.text`
+- Used `Chunk.objects.bulk_update` to persist all `entities_json` in one DB call
+- Updated system prompt wording from "transcript" to "transcript excerpt"
+
+**Resolver changes (`episodes/resolver.py`):**
+- Added `_aggregate_entities_from_chunks()` to collect `{type_key: {name: [(chunk, context), ...]}}` across all chunks
+- Changed resolution to use aggregated unique names per type (same LLM call count as before)
+- Creates `EntityMention` per (entity, chunk) pair using `bulk_create(ignore_conflicts=True)`
+- Changed "no entities" from failure to success — transitions to EMBEDDING
+
+**Admin changes (`episodes/admin.py`):**
+- Added `chunk` to readonly fields on `EntityMentionInlineForEpisode`, `EntityMentionInlineForEntity`, and `EntityMentionAdmin`
+
+**Tests:**
+- Updated `test_extract.py`: tests create chunks, verify `chunk.entities_json` populated, N chunks → N LLM calls, "no chunks" → failure
+- Updated `test_resolve.py`: tests use chunks with `entities_json`, verify chunk FKs on mentions, test same entity in multiple chunks → multiple mentions, test aggregation (one resolution call with unique names), "no entities in any chunk" → success
+
+**README:** Updated Extract and Resolve step descriptions.
+
+All 102 tests pass. Migration applies cleanly. No pending migrations.

--- a/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
+++ b/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
@@ -32,7 +32,7 @@ Read all critical files: `episodes/models.py`, `episodes/extractor.py`, `episode
 **Resolver changes (`episodes/resolver.py`):**
 - Added `_aggregate_entities_from_chunks()` to collect `{type_key: {name: [(chunk, context), ...]}}` across all chunks
 - Changed resolution to use aggregated unique names per type (same LLM call count as before)
-- Creates `EntityMention` per (entity, chunk) pair using `bulk_create(ignore_conflicts=True)`
+- Creates `EntityMention` per (entity, chunk) pair using `bulk_create` (de-duplicated by chunk in `_aggregate_entities_from_chunks()`)
 - Changed "no entities" from failure to success — transitions to EMBEDDING
 
 **Admin changes (`episodes/admin.py`):**
@@ -97,5 +97,21 @@ When no chunks/entities exist, stale `EntityMention` rows from a previous run su
 **Comment 5 — Per-name DB round-trips (`resolver.py:127-138`):**
 One `Entity.objects.create()` + one `bulk_create()` per name.
 **Fix:** Batched all `EntityMention` objects per entity type into a single `bulk_create`. `Entity.objects.create()` per name kept because SQLite doesn't support `bulk_create` returning IDs.
+
+All 102 tests pass after fixes.
+
+### PR Review — Copilot, second round (3 comments)
+
+**Comment 6 — False positive "has entities" check (`resolver.py:107`):**
+`any(chunk.entities_json for chunk in chunks)` treats all-null dicts as truthy, entering the resolution path unnecessarily.
+**Fix:** Moved `_aggregate_entities_from_chunks()` before the early-return check; early-return now uses `if not aggregated:`. Added `mock_factory.assert_not_called()` assertion to `test_null_types_skipped`.
+
+**Comment 7 — Stale `episode.entities_json` (`extractor.py:125`):**
+Extraction no longer writes to `episode.entities_json`, leaving stale data from previous runs.
+**Fix:** Clear `episode.entities_json = None` on successful extraction.
+
+**Comment 8 — Stale docs mentioning `ignore_conflicts` (`implementation-session.md:35`):**
+Session transcript still referenced `bulk_create(ignore_conflicts=True)` after it was removed.
+**Fix:** Updated to reflect current implementation.
 
 All 102 tests pass after fixes.

--- a/doc/sessions/2026-03-15-chunk-level-entity-extraction-planning-session.md
+++ b/doc/sessions/2026-03-15-chunk-level-entity-extraction-planning-session.md
@@ -1,0 +1,36 @@
+# Session: Chunk-level Entity Extraction — Planning
+
+**Session ID:** d8df4186-a362-415c-9d05-bc068bbd5fd0
+**Date:** 2026-03-15
+
+## Summary
+
+Planned the transition from episode-level entity extraction to chunk-level extraction, so each entity mention is linked to the specific chunk (and timestamp) where it appeared.
+
+## Conversation
+
+### User
+Requested analysis of switching extraction and resolution from episode-level to chunk-level. Since chunking now runs before extraction, we should link entities back to where in the episode they were mentioned. Also noted a future requirement: showing users which resolved entities appear in a given episode.
+
+### Assistant
+Explored the current extraction (`episodes/extractor.py`) and resolution (`episodes/resolver.py`) implementation. Key findings:
+
+- Extraction runs on `episode.transcript` (full text), stores result in `episode.entities_json`
+- Resolution iterates `episode.entities_json`, creates `EntityMention` records linked only to episodes
+- `EntityMention` has unique constraint on `(entity, episode, context)` — no chunk linkage
+- Chunks have `text`, `start_time`, `end_time` fields — ideal for provenance
+
+Presented pros and cons comparison:
+
+- **Episode-level pros:** Fewer LLM calls (1 per episode), full transcript context for disambiguation
+- **Chunk-level pros:** Entity provenance with timestamps, RAG alignment (entities and embeddings share the same unit), enables "entities per episode with position" queries
+- **Chunk-level cons:** More LLM calls (~40-60 per episode), less cross-chunk context for disambiguation
+
+Recommended approach: extract per-chunk (provenance is the point), then aggregate unique names and resolve once per entity type (same resolution cost as today). `EntityMention` records created per (entity, chunk) pair.
+
+Proposed model changes: `Chunk.entities_json` for raw extraction, `EntityMention.chunk` FK, constraint change from `(entity, episode, context)` to `(entity, chunk)`. Multi-step migration with data migration to delete existing mentions.
+
+Proposed handling "no entities in any chunk" as success (not failure), since it's a valid state.
+
+### User
+Approved the plan.

--- a/episodes/admin.py
+++ b/episodes/admin.py
@@ -271,7 +271,7 @@ class EpisodeAdmin(admin.ModelAdmin):
 @admin.register(Chunk)
 class ChunkAdmin(admin.ModelAdmin):
     list_display = ("episode_link", "index", "formatted_time_range", "short_text", "has_entities")
-    list_filter = ("episode__title",)
+    list_filter = ("episode",)
     search_fields = ("text", "episode__title")
     readonly_fields = (
         "episode", "index", "text", "start_time", "end_time",

--- a/episodes/admin.py
+++ b/episodes/admin.py
@@ -321,9 +321,6 @@ class ChunkAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
 
 class EntityInlineForEntityType(admin.TabularInline):
     model = Entity

--- a/episodes/admin.py
+++ b/episodes/admin.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib import admin
 from django.db.models import Count
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.html import format_html
 from django_q.tasks import async_task
 
@@ -25,6 +26,20 @@ class ChunkInlineForEpisode(admin.TabularInline):
     verbose_name_plural = "Chunks"
     readonly_fields = ("index", "text", "start_time", "end_time", "segment_start", "segment_end")
     fields = ("index", "start_time", "end_time", "text")
+    show_change_link = True
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class EntityMentionInlineForChunk(admin.TabularInline):
+    model = EntityMention
+    extra = 0
+    fields = ("entity", "context", "created_at")
+    readonly_fields = ("entity", "context", "created_at")
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -36,7 +51,7 @@ class ChunkInlineForEpisode(admin.TabularInline):
 class EntityMentionInlineForEpisode(admin.TabularInline):
     model = EntityMention
     extra = 0
-    readonly_fields = ("entity", "context", "created_at")
+    readonly_fields = ("entity", "chunk", "context", "created_at")
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -48,7 +63,7 @@ class EntityMentionInlineForEpisode(admin.TabularInline):
 class EntityMentionInlineForEntity(admin.TabularInline):
     model = EntityMention
     extra = 0
-    readonly_fields = ("episode", "context", "created_at")
+    readonly_fields = ("episode", "chunk", "context", "created_at")
 
     def has_add_permission(self, request, obj=None):
         return False
@@ -253,6 +268,63 @@ class EpisodeAdmin(admin.ModelAdmin):
         )
 
 
+@admin.register(Chunk)
+class ChunkAdmin(admin.ModelAdmin):
+    list_display = ("episode_link", "index", "formatted_time_range", "short_text", "has_entities")
+    list_filter = ("episode__title",)
+    search_fields = ("text", "episode__title")
+    readonly_fields = (
+        "episode", "index", "text", "start_time", "end_time",
+        "segment_start", "segment_end", "entities_json",
+    )
+
+    def get_inlines(self, request, obj=None):
+        if obj is not None and obj.entity_mentions.exists():
+            return [EntityMentionInlineForChunk]
+        return []
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = [
+            (None, {"fields": ("episode", "index", "start_time", "end_time")}),
+            ("Content", {"fields": ("text",)}),
+            ("Segments", {"classes": ("collapse",), "fields": ("segment_start", "segment_end")}),
+        ]
+        if obj and obj.entities_json:
+            fieldsets.append((
+                "Extracted Entities",
+                {"classes": ("collapse",), "fields": ("entities_json",)},
+            ))
+        return fieldsets
+
+    @admin.display(description="Episode", ordering="episode__title")
+    def episode_link(self, obj):
+        url = reverse("admin:episodes_episode_change", args=[obj.episode_id])
+        return format_html('<a href="{}">{}</a>', url, obj.episode)
+
+    @admin.display(description="Time range", ordering="start_time")
+    def formatted_time_range(self, obj):
+        def fmt(seconds):
+            m, s = divmod(int(seconds), 60)
+            return f"{m}:{s:02d}"
+        return f"{fmt(obj.start_time)} – {fmt(obj.end_time)}"
+
+    @admin.display(description="Text")
+    def short_text(self, obj):
+        if len(obj.text) > 100:
+            return format_html("{}&hellip;", obj.text[:100])
+        return obj.text
+
+    @admin.display(description="Entities", boolean=True)
+    def has_entities(self, obj):
+        return bool(obj.entities_json)
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class EntityInlineForEntityType(admin.TabularInline):
     model = Entity
     extra = 0
@@ -337,10 +409,20 @@ class EntityAdmin(admin.ModelAdmin):
 
 @admin.register(EntityMention)
 class EntityMentionAdmin(admin.ModelAdmin):
-    list_display = ("entity", "episode", "short_context", "created_at")
+    list_display = ("entity", "episode_link", "chunk_link", "short_context", "created_at")
     list_filter = ("entity__entity_type__name",)
     search_fields = ("entity__name", "episode__title")
-    readonly_fields = ("entity", "episode", "context", "created_at")
+    readonly_fields = ("entity", "episode", "chunk", "context", "created_at")
+
+    @admin.display(description="Episode", ordering="episode__title")
+    def episode_link(self, obj):
+        url = reverse("admin:episodes_episode_change", args=[obj.episode_id])
+        return format_html('<a href="{}">{}</a>', url, obj.episode)
+
+    @admin.display(description="Chunk", ordering="chunk__index")
+    def chunk_link(self, obj):
+        url = reverse("admin:episodes_chunk_change", args=[obj.chunk_id])
+        return format_html('<a href="{}">{}</a>', url, obj.chunk)
 
     @admin.display(description="Context")
     def short_context(self, obj):

--- a/episodes/extractor.py
+++ b/episodes/extractor.py
@@ -1,7 +1,7 @@
 import logging
 
 from .languages import ISO_639_LANGUAGE_NAMES, ISO_639_RE
-from .models import EntityType, Episode
+from .models import Chunk, EntityType, Episode
 from .processing import complete_step, fail_step, start_step
 from .providers.factory import get_extraction_provider
 
@@ -118,7 +118,6 @@ def extract_entities(episode_id: int) -> None:
             )
             chunk.entities_json = entities
 
-        from .models import Chunk
         Chunk.objects.bulk_update(chunks, ["entities_json"])
 
         complete_step(episode, Episode.Status.EXTRACTING)

--- a/episodes/extractor.py
+++ b/episodes/extractor.py
@@ -121,8 +121,9 @@ def extract_entities(episode_id: int) -> None:
         Chunk.objects.bulk_update(chunks, ["entities_json"])
 
         complete_step(episode, Episode.Status.EXTRACTING)
+        episode.entities_json = None
         episode.status = Episode.Status.RESOLVING
-        episode.save(update_fields=["status", "updated_at"])
+        episode.save(update_fields=["status", "entities_json", "updated_at"])
     except Exception as exc:
         logger.exception("Failed to extract entities for episode %s", episode_id)
         episode.error_message = str(exc)

--- a/episodes/extractor.py
+++ b/episodes/extractor.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 _BASE_SYSTEM_PROMPT = (
     "You are an expert entity extractor specializing in jazz music podcasts.\n"
-    "Given a podcast transcript, extract all mentioned entities organized by type.\n\n"
+    "Given a transcript excerpt, extract all mentioned entities organized by type.\n\n"
     "Entity types to extract:\n"
 )
 
@@ -97,29 +97,33 @@ def extract_entities(episode_id: int) -> None:
 
     start_step(episode, Episode.Status.EXTRACTING)
 
-    if not episode.transcript:
-        episode.error_message = "No transcript to extract entities from"
+    chunks = list(episode.chunks.order_by("index"))
+    if not chunks:
+        episode.error_message = "No chunks to extract entities from"
         episode.status = Episode.Status.FAILED
         episode.save(update_fields=["status", "error_message", "updated_at"])
-        fail_step(episode, Episode.Status.EXTRACTING, "No transcript to extract entities from")
+        fail_step(episode, Episode.Status.EXTRACTING, "No chunks to extract entities from")
         return
 
     try:
         provider = get_extraction_provider()
         system_prompt = build_system_prompt(episode.language)
         schema = build_response_schema()
-        entities = provider.structured_extract(
-            system_prompt=system_prompt,
-            user_content=episode.transcript,
-            response_schema=schema,
-        )
 
-        episode.entities_json = entities
+        for chunk in chunks:
+            entities = provider.structured_extract(
+                system_prompt=system_prompt,
+                user_content=chunk.text,
+                response_schema=schema,
+            )
+            chunk.entities_json = entities
+
+        from .models import Chunk
+        Chunk.objects.bulk_update(chunks, ["entities_json"])
+
         complete_step(episode, Episode.Status.EXTRACTING)
         episode.status = Episode.Status.RESOLVING
-        episode.save(
-            update_fields=["status", "entities_json", "updated_at"]
-        )
+        episode.save(update_fields=["status", "updated_at"])
     except Exception as exc:
         logger.exception("Failed to extract entities for episode %s", episode_id)
         episode.error_message = str(exc)

--- a/episodes/migrations/0016_chunk_level_extraction.py
+++ b/episodes/migrations/0016_chunk_level_extraction.py
@@ -1,0 +1,59 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def delete_entity_mentions(apps, schema_editor):
+    """Delete all existing EntityMention rows so chunk FK can be made non-nullable."""
+    EntityMention = apps.get_model("episodes", "EntityMention")
+    EntityMention.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("episodes", "0015_remove_resizing_status"),
+    ]
+
+    operations = [
+        # 1. Add entities_json to Chunk
+        migrations.AddField(
+            model_name="chunk",
+            name="entities_json",
+            field=models.JSONField(blank=True, null=True),
+        ),
+        # 2. Add chunk FK to EntityMention (nullable initially)
+        migrations.AddField(
+            model_name="entitymention",
+            name="chunk",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="entity_mentions",
+                to="episodes.chunk",
+            ),
+        ),
+        # 3. Data migration: delete all existing EntityMention rows
+        migrations.RunPython(delete_entity_mentions, migrations.RunPython.noop),
+        # 4. Make chunk non-nullable
+        migrations.AlterField(
+            model_name="entitymention",
+            name="chunk",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="entity_mentions",
+                to="episodes.chunk",
+            ),
+        ),
+        # 5. Drop old unique constraint, add new one
+        migrations.RemoveConstraint(
+            model_name="entitymention",
+            name="unique_entity_episode_context",
+        ),
+        migrations.AddConstraint(
+            model_name="entitymention",
+            constraint=models.UniqueConstraint(
+                fields=["entity", "chunk"],
+                name="unique_entity_chunk",
+            ),
+        ),
+    ]

--- a/episodes/models.py
+++ b/episodes/models.py
@@ -115,14 +115,17 @@ class EntityMention(models.Model):
     episode = models.ForeignKey(
         Episode, on_delete=models.CASCADE, related_name="entity_mentions"
     )
+    chunk = models.ForeignKey(
+        "Chunk", on_delete=models.CASCADE, related_name="entity_mentions"
+    )
     context = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["entity", "episode", "context"],
-                name="unique_entity_episode_context",
+                fields=["entity", "chunk"],
+                name="unique_entity_chunk",
             ),
         ]
 
@@ -138,6 +141,7 @@ class Chunk(models.Model):
     end_time = models.FloatField()
     segment_start = models.PositiveIntegerField()
     segment_end = models.PositiveIntegerField()
+    entities_json = models.JSONField(blank=True, null=True)
 
     class Meta:
         constraints = [

--- a/episodes/resolver.py
+++ b/episodes/resolver.py
@@ -104,9 +104,9 @@ def resolve_entities(episode_id: int) -> None:
     start_step(episode, Episode.Status.RESOLVING)
 
     chunks = list(episode.chunks.order_by("index"))
-    has_any_entities = any(chunk.entities_json for chunk in chunks)
+    aggregated = _aggregate_entities_from_chunks(chunks)
 
-    if not chunks or not has_any_entities:
+    if not aggregated:
         EntityMention.objects.filter(episode=episode).delete()
         complete_step(episode, Episode.Status.RESOLVING)
         episode.status = Episode.Status.EMBEDDING
@@ -115,7 +115,6 @@ def resolve_entities(episode_id: int) -> None:
 
     try:
         provider = get_resolution_provider()
-        aggregated = _aggregate_entities_from_chunks(chunks)
 
         with transaction.atomic():
             # Delete existing mentions for idempotent reprocessing

--- a/episodes/resolver.py
+++ b/episodes/resolver.py
@@ -64,7 +64,10 @@ def _build_system_prompt(entity_type_name, existing_entities):
 
 
 def _aggregate_entities_from_chunks(chunks):
-    """Aggregate entities across chunks into {type_key: {name: [(chunk, context), ...]}}."""
+    """Aggregate entities across chunks into {type_key: {name: [(chunk, context), ...]}}.
+
+    De-duplicates by (name, chunk) — keeps the first context seen per chunk.
+    """
     aggregated = defaultdict(lambda: defaultdict(list))
     for chunk in chunks:
         if not chunk.entities_json:
@@ -72,8 +75,12 @@ def _aggregate_entities_from_chunks(chunks):
         for type_key, entities in chunk.entities_json.items():
             if entities is None:
                 continue
+            seen_chunks = set()
             for entity in entities:
                 name = entity["name"]
+                if (name, chunk.pk) in seen_chunks:
+                    continue
+                seen_chunks.add((name, chunk.pk))
                 context = entity.get("context") or ""
                 aggregated[type_key][name].append((chunk, context))
     return aggregated
@@ -100,6 +107,7 @@ def resolve_entities(episode_id: int) -> None:
     has_any_entities = any(chunk.entities_json for chunk in chunks)
 
     if not chunks or not has_any_entities:
+        EntityMention.objects.filter(episode=episode).delete()
         complete_step(episode, Episode.Status.RESOLVING)
         episode.status = Episode.Status.EMBEDDING
         episode.save(update_fields=["status", "updated_at"])
@@ -131,23 +139,20 @@ def resolve_entities(episode_id: int) -> None:
 
                 if not existing:
                     # No existing entities — create all as new (no LLM call)
+                    all_mentions = []
                     for name in unique_names:
                         entity = Entity.objects.create(
                             entity_type=entity_type,
                             name=name,
                         )
-                        mentions = [
-                            EntityMention(
+                        for chunk, context in names_dict[name]:
+                            all_mentions.append(EntityMention(
                                 entity=entity,
                                 episode=episode,
                                 chunk=chunk,
                                 context=context,
-                            )
-                            for chunk, context in names_dict[name]
-                        ]
-                        EntityMention.objects.bulk_create(
-                            mentions, ignore_conflicts=True
-                        )
+                            ))
+                    EntityMention.objects.bulk_create(all_mentions)
                 else:
                     # LLM resolution against existing entities
                     extracted_names = ", ".join(unique_names)
@@ -161,6 +166,7 @@ def resolve_entities(episode_id: int) -> None:
                     )
 
                     existing_by_id = {e.pk: e for e in existing}
+                    all_mentions = []
 
                     for match in result["matches"]:
                         matched_id = match["matched_entity_id"]
@@ -174,20 +180,15 @@ def resolve_entities(episode_id: int) -> None:
                                 name=match["canonical_name"],
                             )
 
-                        # Create mentions for every (chunk, context) where this name appeared
-                        chunk_contexts = names_dict.get(extracted_name, [])
-                        mentions = [
-                            EntityMention(
+                        # Collect mentions for every (chunk, context) where this name appeared
+                        for chunk, context in names_dict.get(extracted_name, []):
+                            all_mentions.append(EntityMention(
                                 entity=entity,
                                 episode=episode,
                                 chunk=chunk,
                                 context=context,
-                            )
-                            for chunk, context in chunk_contexts
-                        ]
-                        EntityMention.objects.bulk_create(
-                            mentions, ignore_conflicts=True
-                        )
+                            ))
+                    EntityMention.objects.bulk_create(all_mentions)
 
         complete_step(episode, Episode.Status.RESOLVING)
         episode.status = Episode.Status.EMBEDDING

--- a/episodes/resolver.py
+++ b/episodes/resolver.py
@@ -1,8 +1,9 @@
 import logging
+from collections import defaultdict
 
 from django.db import transaction
 
-from .models import Entity, EntityMention, EntityType, Episode
+from .models import Chunk, Entity, EntityMention, EntityType, Episode
 from .processing import complete_step, fail_step, start_step
 from .providers.factory import get_resolution_provider
 
@@ -62,6 +63,22 @@ def _build_system_prompt(entity_type_name, existing_entities):
     )
 
 
+def _aggregate_entities_from_chunks(chunks):
+    """Aggregate entities across chunks into {type_key: {name: [(chunk, context), ...]}}."""
+    aggregated = defaultdict(lambda: defaultdict(list))
+    for chunk in chunks:
+        if not chunk.entities_json:
+            continue
+        for type_key, entities in chunk.entities_json.items():
+            if entities is None:
+                continue
+            for entity in entities:
+                name = entity["name"]
+                context = entity.get("context") or ""
+                aggregated[type_key][name].append((chunk, context))
+    return aggregated
+
+
 def resolve_entities(episode_id: int) -> None:
     try:
         episode = Episode.objects.get(pk=episode_id)
@@ -79,24 +96,24 @@ def resolve_entities(episode_id: int) -> None:
 
     start_step(episode, Episode.Status.RESOLVING)
 
-    if not episode.entities_json:
-        episode.error_message = "No entities to resolve"
-        episode.status = Episode.Status.FAILED
-        episode.save(update_fields=["status", "error_message", "updated_at"])
-        fail_step(episode, Episode.Status.RESOLVING, "No entities to resolve")
+    chunks = list(episode.chunks.order_by("index"))
+    has_any_entities = any(chunk.entities_json for chunk in chunks)
+
+    if not chunks or not has_any_entities:
+        complete_step(episode, Episode.Status.RESOLVING)
+        episode.status = Episode.Status.EMBEDDING
+        episode.save(update_fields=["status", "updated_at"])
         return
 
     try:
         provider = get_resolution_provider()
+        aggregated = _aggregate_entities_from_chunks(chunks)
 
         with transaction.atomic():
             # Delete existing mentions for idempotent reprocessing
             EntityMention.objects.filter(episode=episode).delete()
 
-            for entity_type_key, entities in episode.entities_json.items():
-                if entities is None:
-                    continue
-
+            for entity_type_key, names_dict in aggregated.items():
                 try:
                     entity_type = EntityType.objects.get(key=entity_type_key)
                 except EntityType.DoesNotExist:
@@ -107,27 +124,33 @@ def resolve_entities(episode_id: int) -> None:
                     )
                     continue
 
+                unique_names = list(names_dict.keys())
                 existing = list(
                     Entity.objects.filter(entity_type=entity_type)
                 )
 
                 if not existing:
                     # No existing entities — create all as new (no LLM call)
-                    for extracted in entities:
+                    for name in unique_names:
                         entity = Entity.objects.create(
                             entity_type=entity_type,
-                            name=extracted["name"],
+                            name=name,
                         )
-                        EntityMention.objects.create(
-                            entity=entity,
-                            episode=episode,
-                            context=extracted.get("context") or "",
+                        mentions = [
+                            EntityMention(
+                                entity=entity,
+                                episode=episode,
+                                chunk=chunk,
+                                context=context,
+                            )
+                            for chunk, context in names_dict[name]
+                        ]
+                        EntityMention.objects.bulk_create(
+                            mentions, ignore_conflicts=True
                         )
                 else:
                     # LLM resolution against existing entities
-                    extracted_names = ", ".join(
-                        e["name"] for e in entities
-                    )
+                    extracted_names = ", ".join(unique_names)
                     system_prompt = _build_system_prompt(
                         entity_type_key, existing
                     )
@@ -137,19 +160,11 @@ def resolve_entities(episode_id: int) -> None:
                         response_schema=RESOLUTION_RESPONSE_SCHEMA,
                     )
 
-                    # Build lookup for context by extracted name
-                    context_by_name = {
-                        e["name"]: e.get("context") or ""
-                        for e in entities
-                    }
-
                     existing_by_id = {e.pk: e for e in existing}
 
                     for match in result["matches"]:
                         matched_id = match["matched_entity_id"]
-                        context = context_by_name.get(
-                            match["extracted_name"], ""
-                        )
+                        extracted_name = match["extracted_name"]
 
                         if matched_id is not None and matched_id in existing_by_id:
                             entity = existing_by_id[matched_id]
@@ -159,10 +174,19 @@ def resolve_entities(episode_id: int) -> None:
                                 name=match["canonical_name"],
                             )
 
-                        EntityMention.objects.create(
-                            entity=entity,
-                            episode=episode,
-                            context=context,
+                        # Create mentions for every (chunk, context) where this name appeared
+                        chunk_contexts = names_dict.get(extracted_name, [])
+                        mentions = [
+                            EntityMention(
+                                entity=entity,
+                                episode=episode,
+                                chunk=chunk,
+                                context=context,
+                            )
+                            for chunk, context in chunk_contexts
+                        ]
+                        EntityMention.objects.bulk_create(
+                            mentions, ignore_conflicts=True
                         )
 
         complete_step(episode, Episode.Status.RESOLVING)

--- a/episodes/tests/test_extract.py
+++ b/episodes/tests/test_extract.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import yaml
 from django.test import TestCase, override_settings
 
-from episodes.models import EntityType, Episode
+from episodes.models import Chunk, EntityType, Episode
 
 _YAML_PATH = Path(__file__).resolve().parent.parent / "initial_entity_types.yaml"
 
@@ -56,6 +56,12 @@ class ExtractorBuildPromptTests(TestCase):
         prompt = build_system_prompt("")
         self.assertNotIn("Role", prompt)
         self.assertIn("Artist", prompt)
+
+    def test_system_prompt_says_excerpt(self):
+        from episodes.extractor import build_system_prompt
+
+        prompt = build_system_prompt("")
+        self.assertIn("transcript excerpt", prompt)
 
 
 class ExtractorBuildSchemaTests(TestCase):
@@ -131,6 +137,20 @@ class ExtractEntitiesTests(TestCase):
         with patch("episodes.signals.async_task"):
             return Episode.objects.create(**kwargs)
 
+    def _create_chunks(self, episode, texts):
+        chunks = []
+        for i, text in enumerate(texts):
+            chunks.append(Chunk.objects.create(
+                episode=episode,
+                index=i,
+                text=text,
+                start_time=i * 30.0,
+                end_time=(i + 1) * 30.0,
+                segment_start=i * 10,
+                segment_end=(i + 1) * 10,
+            ))
+        return chunks
+
     @patch("episodes.extractor.get_extraction_provider")
     def test_success(self, mock_factory):
         from episodes.extractor import extract_entities
@@ -144,16 +164,41 @@ class ExtractEntitiesTests(TestCase):
             status=Episode.Status.EXTRACTING,
             transcript="Miles Davis played trumpet on Kind of Blue in 1959.",
         )
+        self._create_chunks(episode, ["Miles Davis played trumpet.", "Kind of Blue in 1959."])
 
         with patch("episodes.signals.async_task"):
             extract_entities(episode.pk)
 
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.RESOLVING)
-        self.assertEqual(episode.entities_json, self.SAMPLE_ENTITIES)
+
+        # Each chunk should have entities_json populated
+        for chunk in episode.chunks.all():
+            self.assertEqual(chunk.entities_json, self.SAMPLE_ENTITIES)
 
     @patch("episodes.extractor.get_extraction_provider")
-    def test_calls_provider_with_correct_args(self, mock_factory):
+    def test_n_chunks_n_llm_calls(self, mock_factory):
+        """N chunks should produce N LLM calls."""
+        from episodes.extractor import extract_entities
+
+        mock_provider = MagicMock()
+        mock_provider.structured_extract.return_value = self.SAMPLE_ENTITIES
+        mock_factory.return_value = mock_provider
+
+        episode = self._create_episode(
+            url="https://example.com/ep/ext-ncalls",
+            status=Episode.Status.EXTRACTING,
+            transcript="Some transcript.",
+        )
+        self._create_chunks(episode, ["chunk 1", "chunk 2", "chunk 3"])
+
+        with patch("episodes.signals.async_task"):
+            extract_entities(episode.pk)
+
+        self.assertEqual(mock_provider.structured_extract.call_count, 3)
+
+    @patch("episodes.extractor.get_extraction_provider")
+    def test_calls_provider_with_chunk_text(self, mock_factory):
         from episodes.extractor import extract_entities
 
         mock_provider = MagicMock()
@@ -166,6 +211,7 @@ class ExtractEntitiesTests(TestCase):
             transcript="Some transcript.",
             language="fr",
         )
+        self._create_chunks(episode, ["Chunk text here."])
 
         with patch("episodes.signals.async_task"):
             extract_entities(episode.pk)
@@ -173,16 +219,16 @@ class ExtractEntitiesTests(TestCase):
         mock_provider.structured_extract.assert_called_once()
         _, kwargs = mock_provider.structured_extract.call_args
         self.assertIn("French", kwargs["system_prompt"])
-        self.assertEqual(kwargs["user_content"], "Some transcript.")
+        self.assertEqual(kwargs["user_content"], "Chunk text here.")
         self.assertIn("schema", kwargs["response_schema"])
 
-    def test_missing_transcript(self):
+    def test_no_chunks(self):
         from episodes.extractor import extract_entities
 
         episode = self._create_episode(
             url="https://example.com/ep/ext-2",
             status=Episode.Status.EXTRACTING,
-            transcript="",
+            transcript="Some transcript but no chunks.",
         )
 
         with patch("episodes.signals.async_task"):
@@ -190,7 +236,7 @@ class ExtractEntitiesTests(TestCase):
 
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.FAILED)
-        self.assertIn("No transcript", episode.error_message)
+        self.assertIn("No chunks", episode.error_message)
 
     def test_wrong_status(self):
         from episodes.extractor import extract_entities
@@ -223,6 +269,7 @@ class ExtractEntitiesTests(TestCase):
             status=Episode.Status.EXTRACTING,
             transcript="Some transcript.",
         )
+        self._create_chunks(episode, ["Some transcript."])
 
         with patch("episodes.signals.async_task"):
             extract_entities(episode.pk)

--- a/episodes/tests/test_resolve.py
+++ b/episodes/tests/test_resolve.py
@@ -362,7 +362,7 @@ class ResolveEntitiesTests(TestCase):
 
     @patch("episodes.resolver.get_resolution_provider")
     def test_null_types_skipped(self, mock_factory):
-        """Entity types with null value are skipped."""
+        """Entity types with null value are skipped — no provider call needed."""
         from episodes.resolver import resolve_entities
 
         mock_provider = MagicMock()
@@ -386,6 +386,8 @@ class ResolveEntitiesTests(TestCase):
         self.assertEqual(episode.status, Episode.Status.EMBEDDING)
         self.assertEqual(Entity.objects.count(), 0)
         self.assertEqual(EntityMention.objects.count(), 0)
+        # All-null dict should early-return without calling the provider
+        mock_factory.assert_not_called()
 
     @patch("episodes.resolver.get_resolution_provider")
     def test_unmatched_canonical_name_already_exists(self, mock_factory):

--- a/episodes/tests/test_resolve.py
+++ b/episodes/tests/test_resolve.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import yaml
 from django.test import TestCase, override_settings
 
-from episodes.models import Entity, EntityMention, EntityType, Episode
+from episodes.models import Chunk, Entity, EntityMention, EntityType, Episode
 
 _FIXTURES_DIR = Path(__file__).parent / "fixtures"
 _YAML_PATH = Path(__file__).resolve().parent.parent / "initial_entity_types.yaml"
@@ -53,6 +53,18 @@ class ResolveEntitiesTests(TestCase):
         with patch("episodes.signals.async_task"):
             return Episode.objects.create(**kwargs)
 
+    def _create_chunk(self, episode, index=0, entities_json=None, text="chunk text"):
+        return Chunk.objects.create(
+            episode=episode,
+            index=index,
+            text=text,
+            start_time=index * 30.0,
+            end_time=(index + 1) * 30.0,
+            segment_start=index * 10,
+            segment_end=(index + 1) * 10,
+            entities_json=entities_json,
+        )
+
     @patch("episodes.resolver.get_resolution_provider")
     def test_resolve_new_entities(self, mock_factory):
         """No existing DB entities — all created as new, no LLM call."""
@@ -64,8 +76,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-1",
             status=Episode.Status.RESOLVING,
-            entities_json=self.SAMPLE_ENTITIES,
         )
+        self._create_chunk(episode, index=0, entities_json=self.SAMPLE_ENTITIES)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
@@ -79,6 +91,10 @@ class ResolveEntitiesTests(TestCase):
         # 59 entities from fixture (3 null types: album, recording_session, label)
         self.assertEqual(Entity.objects.count(), 59)
         self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 59)
+
+        # All mentions have chunk FK set
+        for mention in EntityMention.objects.filter(episode=episode):
+            self.assertIsNotNone(mention.chunk_id)
 
     @patch("episodes.resolver.get_resolution_provider")
     def test_resolve_matches_existing(self, mock_factory):
@@ -112,8 +128,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-2",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        chunk = self._create_chunk(episode, index=0, entities_json=entities_json)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
@@ -125,9 +141,10 @@ class ResolveEntitiesTests(TestCase):
         self.assertEqual(
             Entity.objects.filter(entity_type=artist_type).count(), 1
         )
-        # But a mention was created
+        # Mention was created with chunk FK
         mention = EntityMention.objects.get(episode=episode)
         self.assertEqual(mention.entity, existing)
+        self.assertEqual(mention.chunk, chunk)
         self.assertEqual(mention.context, "trumpet player")
 
     @patch("episodes.resolver.get_resolution_provider")
@@ -167,8 +184,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-3",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        self._create_chunk(episode, index=0, entities_json=entities_json)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
@@ -181,6 +198,107 @@ class ResolveEntitiesTests(TestCase):
             Entity.objects.filter(entity_type=artist_type).count(), 2
         )
         self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 2)
+
+    @patch("episodes.resolver.get_resolution_provider")
+    def test_same_entity_in_multiple_chunks(self, mock_factory):
+        """Same entity in multiple chunks creates multiple mentions."""
+        from episodes.resolver import resolve_entities
+
+        mock_provider = MagicMock()
+        mock_factory.return_value = mock_provider
+
+        entities_chunk1 = {
+            "artist": [
+                {"name": "Miles Davis", "context": "early career"},
+            ],
+        }
+        entities_chunk2 = {
+            "artist": [
+                {"name": "Miles Davis", "context": "later work"},
+            ],
+        }
+
+        episode = self._create_episode(
+            url="https://example.com/ep/res-multi",
+            status=Episode.Status.RESOLVING,
+        )
+        chunk1 = self._create_chunk(episode, index=0, entities_json=entities_chunk1)
+        chunk2 = self._create_chunk(episode, index=1, entities_json=entities_chunk2)
+
+        with patch("episodes.signals.async_task"):
+            resolve_entities(episode.pk)
+
+        episode.refresh_from_db()
+        self.assertEqual(episode.status, Episode.Status.EMBEDDING)
+
+        # 1 entity, but 2 mentions (one per chunk)
+        self.assertEqual(Entity.objects.count(), 1)
+        mentions = EntityMention.objects.filter(episode=episode).order_by("chunk__index")
+        self.assertEqual(mentions.count(), 2)
+        self.assertEqual(mentions[0].chunk, chunk1)
+        self.assertEqual(mentions[0].context, "early career")
+        self.assertEqual(mentions[1].chunk, chunk2)
+        self.assertEqual(mentions[1].context, "later work")
+
+    @patch("episodes.resolver.get_resolution_provider")
+    def test_aggregation_one_resolution_call(self, mock_factory):
+        """Multiple chunks with same entity type → one resolution call with unique names."""
+        from episodes.resolver import resolve_entities
+
+        artist_type = _get_entity_type("artist")
+        existing = Entity.objects.create(
+            entity_type=artist_type, name="Miles Davis"
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.structured_extract.return_value = {
+            "matches": [
+                {
+                    "extracted_name": "Miles Davis",
+                    "canonical_name": "Miles Davis",
+                    "matched_entity_id": existing.pk,
+                },
+                {
+                    "extracted_name": "John Coltrane",
+                    "canonical_name": "John Coltrane",
+                    "matched_entity_id": None,
+                },
+            ],
+        }
+        mock_factory.return_value = mock_provider
+
+        entities_chunk1 = {
+            "artist": [
+                {"name": "Miles Davis", "context": "trumpet"},
+            ],
+        }
+        entities_chunk2 = {
+            "artist": [
+                {"name": "Miles Davis", "context": "bandleader"},
+                {"name": "John Coltrane", "context": "saxophone"},
+            ],
+        }
+
+        episode = self._create_episode(
+            url="https://example.com/ep/res-agg",
+            status=Episode.Status.RESOLVING,
+        )
+        self._create_chunk(episode, index=0, entities_json=entities_chunk1)
+        self._create_chunk(episode, index=1, entities_json=entities_chunk2)
+
+        with patch("episodes.signals.async_task"):
+            resolve_entities(episode.pk)
+
+        # Only 1 LLM call (one entity type: artist)
+        self.assertEqual(mock_provider.structured_extract.call_count, 1)
+
+        # Unique names sent to resolution
+        call_kwargs = mock_provider.structured_extract.call_args[1]
+        self.assertIn("Miles Davis", call_kwargs["user_content"])
+        self.assertIn("John Coltrane", call_kwargs["user_content"])
+
+        # 3 mentions total: Miles in chunk0, Miles in chunk1, Coltrane in chunk1
+        self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 3)
 
     @patch("episodes.resolver.get_resolution_provider")
     def test_resolve_canonical_name(self, mock_factory):
@@ -199,8 +317,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-4",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        self._create_chunk(episode, index=0, entities_json=entities_json)
 
         instrument_type = _get_entity_type("instrument")
 
@@ -225,12 +343,12 @@ class ResolveEntitiesTests(TestCase):
         episode2 = self._create_episode(
             url="https://example.com/ep/res-4b",
             status=Episode.Status.RESOLVING,
-            entities_json={
-                "instrument": [
-                    {"name": "Saxophone", "context": "English spelling"},
-                ],
-            },
         )
+        self._create_chunk(episode2, index=0, entities_json={
+            "instrument": [
+                {"name": "Saxophone", "context": "English spelling"},
+            ],
+        })
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode2.pk)
@@ -258,8 +376,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-5",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        self._create_chunk(episode, index=0, entities_json=entities_json)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
@@ -300,8 +418,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-dup",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        self._create_chunk(episode, index=0, entities_json=entities_json)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
@@ -316,22 +434,21 @@ class ResolveEntitiesTests(TestCase):
         mention = EntityMention.objects.get(episode=episode)
         self.assertEqual(mention.entity, existing)
 
-    def test_missing_entities_json(self):
-        """Null entities_json → FAILED."""
+    def test_no_entities_in_any_chunk_succeeds(self):
+        """No entities in any chunk → success (transition to EMBEDDING)."""
         from episodes.resolver import resolve_entities
 
         episode = self._create_episode(
-            url="https://example.com/ep/res-6",
+            url="https://example.com/ep/res-empty",
             status=Episode.Status.RESOLVING,
-            entities_json=None,
         )
+        self._create_chunk(episode, index=0, entities_json=None)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
 
         episode.refresh_from_db()
-        self.assertEqual(episode.status, Episode.Status.FAILED)
-        self.assertIn("No entities", episode.error_message)
+        self.assertEqual(episode.status, Episode.Status.EMBEDDING)
 
     def test_wrong_status(self):
         """Not RESOLVING → no-op."""
@@ -375,8 +492,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-8",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        self._create_chunk(episode, index=0, entities_json=entities_json)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
@@ -396,8 +513,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-9",
             status=Episode.Status.RESOLVING,
-            entities_json=self.SAMPLE_ENTITIES,
         )
+        self._create_chunk(episode, index=0, entities_json=self.SAMPLE_ENTITIES)
 
         # First run — no existing entities, creates all 59 as new (no LLM call)
         with patch("episodes.signals.async_task"):
@@ -409,7 +526,6 @@ class ResolveEntitiesTests(TestCase):
 
         # Build mock responses for second run: every entity matches its existing record
         def mock_structured_extract(system_prompt, user_content, response_schema):
-            # Parse entity type from system prompt
             for entity_type_key, entities in self.SAMPLE_ENTITIES.items():
                 if entities is None:
                     continue
@@ -465,8 +581,8 @@ class ResolveEntitiesTests(TestCase):
         episode = self._create_episode(
             url="https://example.com/ep/res-unknown",
             status=Episode.Status.RESOLVING,
-            entities_json=entities_json,
         )
+        self._create_chunk(episode, index=0, entities_json=entities_json)
 
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)


### PR DESCRIPTION
## Summary

- **Extract entities per chunk** instead of per episode, linking each `EntityMention` to the specific chunk (and timestamp) where it appeared
- **Aggregate unique names** across all chunks before resolving per type — same LLM call count for resolution as before
- **Register `ChunkAdmin`** (read-only) with entity mention inline, clickable episode/chunk links in EntityMention list view
- **Model changes:** `Chunk.entities_json`, `EntityMention.chunk` FK, unique constraint `(entity, chunk)` replacing `(entity, episode, context)`

## Test plan

- [x] `uv run python manage.py migrate` — applies cleanly
- [x] `uv run python manage.py test episodes` — all 102 tests pass
- [x] Admin: EntityMention list shows clickable Episode and Chunk columns
- [x] Admin: Chunk list view shows episode link, time range, text preview, entities boolean
- [x] Admin: Chunk detail page shows entity mention inline (without Episode column)
- [x] Admin: Episode detail chunk inline has "change link" to chunk detail

## Documentation

- [Plan](doc/plans/chunk-level-entity-extraction.md)
- [Feature](doc/features/chunk-level-entity-extraction.md)
- [Planning session](doc/sessions/2026-03-15-chunk-level-entity-extraction-planning-session.md)
- [Implementation session](doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md)
- [Changelog](CHANGELOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)