### PR TITLE
Rename entity type keys to match Wikidata labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2026-03-16
+
+### Changed
+
+- Rename Entity Type Keys to Match Wikidata Labels — align 8 entity type keys, names, and descriptions with official Wikidata labels (e.g., artist -> musician, band -> musical_group), fix incorrect Q-ID for recording_session (was a galaxy, now Q98216532) — [plan](doc/plans/wikidata-entity-type-renames.md), [feature](doc/features/wikidata-entity-type-renames.md), [planning session](doc/sessions/2026-03-16-wikidata-entity-type-renames-planning-session.md), [implementation session](doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md)
+
 ## 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ RAGtime is a Django application for ingesting jazz-related podcast episodes. It 
 
 - 🎙️ **Episode Ingestion** — Add podcast episodes by URL. RAGtime scrapes metadata (title, description, date, image), downloads audio, and processes it through the pipeline.
 - 📝 **Multilingual Transcription** — Transcribes episodes using configurable backends (Whisper API by default) with segment and word-level timestamps. Supports multiple languages (English, Spanish, German, Swedish, etc.).
-- 🔍 **Entity Extraction** — Identifies jazz entities: artists, bands, albums, venues, recording sessions, record labels, years. Entities are resolved against existing records using LLM-based matching.
+- 🔍 **Entity Extraction** — Identifies jazz entities: musicians, musical groups, albums, music venues, recording sessions, record labels, years. Entities are resolved against existing records using LLM-based matching.
 - 📇 **Episode Indexing** — Splits transcripts into segments and generates multilingual embeddings stored in ChromaDB. Enables cross-language semantic search so Scott can retrieve relevant content regardless of the question's language.
 - 🎷 **Scott — Your Jazz AI** — A conversational agent that answers questions strictly from ingested episode content. Scott responds in the user's language and provides references to specific episodes and timestamps. Responses stream in real-time.
 
@@ -61,7 +61,7 @@ Split transcript into ~150-word chunks along Whisper segment boundaries, with 1-
 
 #### 7. 🔍 Extract entities (status: `extracting`)
 
-LLM-based entity extraction runs **per chunk**, linking each entity mention to the specific chunk (and thus timestamp) where it appeared. Entity types (artist, band, album, composition, venue, recording session, label, year, era, city, country, sub-genre, instrument, role) are stored in the database and managed via Django admin. Each entity type has a **Wikidata class Q-ID** (e.g., Q639669 for "musician") for candidate lookup during resolution. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with:
+LLM-based entity extraction runs **per chunk**, linking each entity mention to the specific chunk (and thus timestamp) where it appeared. Entity types (musician, musical group, album, composed musical work, music venue, recording session, record label, year, historical period, city, country, music genre, musical instrument, role) are stored in the database and managed via Django admin. Each entity type has a **Wikidata class Q-ID** (e.g., Q639669 for "musician") for candidate lookup during resolution. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with:
 
 ```
 uv run python manage.py load_entity_types

--- a/doc/features/wikidata-entity-type-renames.md
+++ b/doc/features/wikidata-entity-type-renames.md
@@ -1,0 +1,35 @@
+# Feature: Rename Entity Type Keys to Match Wikidata Labels
+
+## Problem
+
+Entity type keys in `initial_entity_types.yaml` used informal names (e.g., "artist", "band", "label") that didn't match the official Wikidata labels for their associated Q-IDs. Additionally, the `recording_session` entry (Q81091849) pointed to a galaxy in the constellation Virgo, not a recording session.
+
+## Changes
+
+- **8 entity types renamed** — keys, names, and descriptions updated to match Wikidata labels verbatim (e.g., `artist` -> `musician`, `band` -> `musical_group`)
+- **1 Q-ID fixed** — `recording_session` changed from Q81091849 (galaxy) to Q98216532 (recording session)
+- **Examples adjusted** — added examples where appropriate (e.g., Thelonious Monk, Weather Report, Blue Note Jazz Club); replaced "Post-Bop" in historical_period with "The Harlem Renaissance"
+- **Test data updated** — all test fixtures and inline test data use new keys
+- **README updated** — entity type listings in Features and Extract sections
+
+## Key Parameters
+
+No tunable constants. All names and descriptions come directly from Wikidata API responses.
+
+## Verification
+
+```bash
+uv run python manage.py test                    # All 150 tests pass
+rm db.sqlite3 && uv run python manage.py migrate  # Fresh DB gets new keys
+uv run python manage.py load_entity_types        # Verify new names in admin
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `episodes/initial_entity_types.yaml` | 8 key/name/description renames, 1 Q-ID fix, example adjustments |
+| `episodes/tests/fixtures/wdr-giant-steps-django-reinhardt-episode-extracted-entities.json` | JSON keys renamed to match new entity type keys |
+| `episodes/tests/test_extract.py` | SAMPLE_ENTITIES keys, schema test, prompt assertions updated |
+| `episodes/tests/test_resolve.py` | `_get_entity_type()` calls and inline test data updated |
+| `README.md` | Entity type listings in Features and Extract sections updated |

--- a/doc/features/wikidata-entity-type-renames.md
+++ b/doc/features/wikidata-entity-type-renames.md
@@ -14,7 +14,9 @@ Entity type keys in `initial_entity_types.yaml` used informal names (e.g., "arti
 
 ## Key Parameters
 
-No tunable constants. All names and descriptions come directly from Wikidata API responses.
+No tunable constants. Names and descriptions for the 8 renamed types come from Wikidata API responses. Types that were not renamed (e.g., `recording_session`, `album`, `year`) retain their existing descriptions and examples.
+
+**Note:** This project has not been released yet, so there are no existing installs to migrate. A fresh `migrate` + `load_entity_types` is sufficient.
 
 ## Verification
 

--- a/doc/plans/wikidata-entity-type-renames.md
+++ b/doc/plans/wikidata-entity-type-renames.md
@@ -1,0 +1,41 @@
+# Plan: Rename Entity Type Keys to Match Wikidata Labels
+
+## Problem
+
+Entity type keys and names in `initial_entity_types.yaml` were manually chosen and didn't always match the official Wikidata labels for their associated Q-IDs. One entry (`recording_session` / Q81091849) pointed to a galaxy instead of a recording session. Aligning keys, names, and descriptions with Wikidata ensures consistency and correctness.
+
+## Approach
+
+1. Verify each Wikidata Q-ID via the Wikidata API (`wbgetentities`)
+2. For 8 entity types where the Wikidata label differs from the YAML name, update key, name, and description to match Wikidata verbatim
+3. Fix the incorrect Q-ID for `recording_session` (Q81091849 galaxy -> Q98216532 recording session)
+4. Propagate key renames across all test fixtures, test data, and README
+
+## Key Renames
+
+| Old key | New key | Wikidata ID | Wikidata Label |
+|---------|---------|-------------|----------------|
+| artist | musician | Q639669 | musician |
+| band | musical_group | Q215380 | musical group |
+| composition | composed_musical_work | Q207628 | composed musical work |
+| venue | music_venue | Q8719053 | music venue |
+| label | record_label | Q18127 | record label |
+| era | historical_period | Q11514315 | historical period |
+| sub_genre | music_genre | Q188451 | music genre |
+| instrument | musical_instrument | Q34379 | musical instrument |
+
+## Unchanged Types
+
+- album (Q482994) - already matches
+- recording_session (Q-ID fixed to Q98216532)
+- year (Q577) - already matches
+- city (Q515) - already matches
+- country (Q6256) - already matches
+- role (Q12737077) - kept as-is
+
+## Impact
+
+- No migration needed: entity types are seeded from YAML at migration time and via `load_entity_types`
+- Test fixtures and test data updated to use new keys
+- README entity type listings updated
+- Extractor and resolver read keys dynamically from DB, so no production code changes needed

--- a/doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md
+++ b/doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md
@@ -45,5 +45,22 @@ Applied changes in the following order:
 ### Considerations
 
 - No production code changes needed: `extractor.py` and `resolver.py` read entity type keys dynamically from the database
-- No migration changes needed: migration 0010 reads from the YAML file at migration time
+- No migration changes needed: migration 0010 reads from the YAML file at migration time; project has not been released so no existing installs to migrate
 - The `label` field in JSON responses (e.g., Wikidata search results) is unrelated to the entity type key rename from `label` to `record_label`
+
+## PR Review Comments (Copilot)
+
+7 comments received. Actions taken:
+
+### Dismissed (3 comments — no existing installs)
+
+1. **doc/plans** — Copilot flagged that `load_entity_types` uses `update_or_create(key=...)` so renaming keys would create duplicates on existing DBs and leave historical `Chunk.entities_json` with old keys. **Dismissed:** project has not been released, no existing installs to migrate.
+2. **doc/features (verification)** — Same concern: verification only covers fresh DB. **Dismissed:** same reason.
+3. **CHANGELOG.md** — Should mark as breaking change for existing installs. **Dismissed:** same reason.
+
+### Accepted (4 comments — code cleanup)
+
+4. **doc/features (key parameters)** — "All names and descriptions come directly from Wikidata" is inaccurate for `recording_session` (custom description) and examples (curated). **Fixed:** reworded to clarify that only the 8 renamed types use Wikidata descriptions; added note about no existing installs.
+5. **test_extract.py** — Variable `artist_prop` misleading since it references `musician` property. **Fixed:** renamed to `musician_prop`.
+6. **test_resolve.py:108** — Variable `artist_type` now holds `musician` EntityType. **Fixed:** renamed all `artist_type` occurrences to `musician_type` throughout the file.
+7. **test_resolve.py:257** — Same `artist_type` issue + inline comments still say "artist". **Fixed:** covered by #6; also updated 3 comments ("artist entity" -> "musician entity", "entity type: artist" -> "entity type: musician", "null types: label" -> "null types: record_label").

--- a/doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md
+++ b/doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md
@@ -1,0 +1,49 @@
+# Implementation Session: Rename Entity Type Keys to Match Wikidata Labels
+
+## Session ID
+
+Claude Code session (worktree: wikidata-entity-type-renames)
+
+## Summary
+
+Renamed 8 entity type keys to match Wikidata labels, fixed 1 incorrect Q-ID, and propagated changes across test fixtures, test data, and README.
+
+### Assistant
+
+Applied changes in the following order:
+
+1. **Updated `episodes/initial_entity_types.yaml`** — 8 sequential edits, one per entity type:
+   - artist -> musician (Q639669)
+   - band -> musical_group (Q215380)
+   - composition -> composed_musical_work (Q207628)
+   - venue -> music_venue (Q8719053)
+   - label -> record_label (Q18127)
+   - era -> historical_period (Q11514315)
+   - sub_genre -> music_genre (Q188451)
+   - instrument -> musical_instrument (Q34379)
+
+   Each edit updated key, name, description (from Wikidata), and examples where appropriate.
+
+2. **Updated test fixture** (`episodes/tests/fixtures/wdr-giant-steps-django-reinhardt-episode-extracted-entities.json`) — renamed 8 JSON keys to match new entity type keys.
+
+3. **Updated `episodes/tests/test_extract.py`**:
+   - `SAMPLE_ENTITIES` dict keys renamed
+   - Schema test changed from `inner["properties"]["artist"]` to `inner["properties"]["musician"]`
+   - Prompt assertions changed from `"Artist"` to `"Musician"`
+
+4. **Updated `episodes/tests/test_resolve.py`**:
+   - All `_get_entity_type("artist")` -> `_get_entity_type("musician")` (replace_all)
+   - All `_get_entity_type("instrument")` -> `_get_entity_type("musical_instrument")` (replace_all)
+   - All inline test data dict keys renamed via replace_all
+
+5. **Updated `README.md`** — entity type listings in Features section and Extract entities section.
+
+6. **Fixed recording_session Q-ID** — changed from Q81091849 (galaxy) to Q98216532 (recording session).
+
+7. **Ran all 150 tests** — all passed.
+
+### Considerations
+
+- No production code changes needed: `extractor.py` and `resolver.py` read entity type keys dynamically from the database
+- No migration changes needed: migration 0010 reads from the YAML file at migration time
+- The `label` field in JSON responses (e.g., Wikidata search results) is unrelated to the entity type key rename from `label` to `record_label`

--- a/doc/sessions/2026-03-16-wikidata-entity-type-renames-planning-session.md
+++ b/doc/sessions/2026-03-16-wikidata-entity-type-renames-planning-session.md
@@ -1,0 +1,62 @@
+# Planning Session: Rename Entity Type Keys to Match Wikidata Labels
+
+## Session ID
+
+Claude Code session (worktree: wikidata-entity-type-renames)
+
+## Summary
+
+Verified all 14 Wikidata Q-IDs in `initial_entity_types.yaml` against the Wikidata API, identified 8 mismatched labels, 1 incorrect Q-ID, and planned the rename strategy.
+
+### User
+
+Check the Wikidata ID associated to each of the entities in file initial_entity_types.yaml and report here whether the rest of the information configured in the YAML matches the information provided by Wikidata for that ID.
+
+### Assistant
+
+Read the YAML file containing 14 entity types. Fetched all 14 Wikidata entries via the Wikidata API (`wbgetentities` endpoint) in two parallel batch requests.
+
+Produced a comparison table:
+
+| Key | YAML Name | Wikidata ID | Wikidata Label | Match? |
+|-----|-----------|-------------|----------------|--------|
+| artist | Artist | Q639669 | musician | ~Close |
+| band | Band | Q215380 | musical group | ~Close |
+| album | Album | Q482994 | album | OK |
+| composition | Composition | Q207628 | composed musical work | OK |
+| venue | Venue | Q8719053 | music venue | OK |
+| recording_session | Recording Session | Q81091849 | (no label) | WRONG - galaxy |
+| label | Label | Q18127 | record label | OK |
+| year | Year | Q577 | year | OK |
+| era | Era | Q11514315 | historical period | OK |
+| city | City | Q515 | city | OK |
+| country | Country | Q6256 | country | OK |
+| sub_genre | Sub-genre | Q188451 | music genre | ~Close |
+| instrument | Instrument | Q34379 | musical instrument | OK |
+| role | Role | Q12737077 | occupation | ~Close |
+
+Key findings:
+- 1 incorrect Q-ID: `recording_session` (Q81091849) is a galaxy, not a recording session
+- 3 approximate matches where labels differ (artist/musician, band/musical group, sub_genre/music genre)
+- 1 debatable match (role/occupation)
+- 9 good/perfect matches
+
+### User
+
+For Wikidata IDs Q639669, Q215380, Q207628, Q8719053, Q18127, Q11514315, Q188451, Q34379 using the Wikidata Label update the YAML name, key, description and examples.
+
+### Assistant
+
+Explored the codebase to assess impact. Found references in: YAML seed file, test fixtures (JSON), test_extract.py, test_resolve.py, README.md, extractor.py, resolver.py, admin.py, and management commands.
+
+Determined that extractor and resolver read keys dynamically from the DB, so no production code changes needed — only the YAML, tests, fixtures, and README require updates.
+
+Planned the 8 renames and propagated changes across all 5 affected files.
+
+### User
+
+For recording_session, change the Wikidata ID to Q98216532.
+
+### Assistant
+
+Verified Q98216532 via Wikidata API: "recording session — period of time devoted to recording music in a studio". Updated the YAML.

--- a/episodes/initial_entity_types.yaml
+++ b/episodes/initial_entity_types.yaml
@@ -1,18 +1,20 @@
-- key: artist
-  name: Artist
+- key: musician
+  name: Musician
   wikidata_id: Q639669
-  description: Individual musicians or singers.
+  description: Person who composes, conducts or performs music.
   examples:
     - Miles Davis
     - Alice Coltrane
+    - Thelonious Monk
 
-- key: band
-  name: Band
+- key: musical_group
+  name: Musical Group
   wikidata_id: Q215380
-  description: Organized groups or ensembles.
+  description: Musical ensemble which performs music.
   examples:
     - The Jazz Messengers
     - Snarky Puppy
+    - Weather Report
 
 - key: album
   name: Album
@@ -22,35 +24,36 @@
     - Kind of Blue
     - A Love Supreme
 
-- key: composition
-  name: Composition
+- key: composed_musical_work
+  name: Composed Musical Work
   wikidata_id: Q207628
-  description: Specific songs, standards, or tunes.
+  description: Original piece or work of music, either vocal or instrumental.
   examples:
     - Take Five
     - Giant Steps
     - Summertime
 
-- key: venue
-  name: Venue
+- key: music_venue
+  name: Music Venue
   wikidata_id: Q8719053
-  description: Physical clubs, theaters, or festivals.
+  description: Any location used for a concert or musical performance.
   examples:
     - Village Vanguard
     - Newport Jazz Festival
+    - Blue Note Jazz Club
 
 - key: recording_session
   name: Recording Session
-  wikidata_id: Q81091849
+  wikidata_id: Q98216532
   description: A specific date/time/place of a recording.
   examples:
     - The Blackhawk Sessions
     - 1959 Sessions
 
-- key: label
-  name: Label
+- key: record_label
+  name: Record Label
   wikidata_id: Q18127
-  description: The record company/publisher.
+  description: Brand and trademark associated with the marketing of music recordings and music videos.
   examples:
     - Blue Note
     - "Impulse!"
@@ -65,14 +68,14 @@
     - "1942"
     - "2024"
 
-- key: era
-  name: Era
+- key: historical_period
+  name: Historical Period
   wikidata_id: Q11514315
-  description: Broad historical periods or movements.
+  description: Segment of time in history.
   examples:
     - The Swing Era
     - Prohibition
-    - Post-Bop
+    - The Harlem Renaissance
 
 - key: city
   name: City
@@ -93,20 +96,20 @@
     - Ethiopia
     - France
 
-- key: sub_genre
-  name: Sub-genre
+- key: music_genre
+  name: Music Genre
   wikidata_id: Q188451
-  description: Specific stylistic categories within Jazz.
+  description: Category that identifies pieces of music as belonging to a shared tradition or set of conventions.
   examples:
+    - Bebop
     - Hard Bop
     - Fusion
-    - Modal
     - Free Jazz
 
-- key: instrument
-  name: Instrument
+- key: musical_instrument
+  name: Musical Instrument
   wikidata_id: Q34379
-  description: The tool used to create the music.
+  description: Device created or adapted to make musical sounds.
   examples:
     - Trumpet
     - Fender Rhodes

--- a/episodes/tests/fixtures/wdr-giant-steps-django-reinhardt-episode-extracted-entities.json
+++ b/episodes/tests/fixtures/wdr-giant-steps-django-reinhardt-episode-extracted-entities.json
@@ -1,5 +1,5 @@
 {
-  "artist": [
+  "musician": [
     {
       "name": "Django Reinhardt",
       "context": "Hauptthema des Podcasts, herausragender Gypsy Jazz Gitarrist"
@@ -49,7 +49,7 @@
       "context": "Pianist und Leiter des Modern Jazz Quartet, schrieb die Komposition 'Django' zu Ehren Reinhardts"
     }
   ],
-  "band": [
+  "musical_group": [
     {
       "name": "Quintet du Oddclub de France",
       "context": "Django Reinhardts Ensemble mit Stéphane Grappelli und weiteren Rhythmus-Gitarristen"
@@ -60,7 +60,7 @@
     }
   ],
   "album": null,
-  "composition": [
+  "composed_musical_work": [
     {
       "name": "Nuage",
       "context": "Melancholischer Titel von Django Reinhardt, Sinnbild für Heimat der Sinti und Roma"
@@ -74,7 +74,7 @@
       "context": "Komposition von John Lewis zu Ehren Django Reinhardts, wird Jazz-Standard"
     }
   ],
-  "venue": [
+  "music_venue": [
     {
       "name": "52. Straße von New York",
       "context": "Ort von Salons, wo Django nach Kriegsende spielt"
@@ -89,7 +89,7 @@
     }
   ],
   "recording_session": null,
-  "label": null,
+  "record_label": null,
   "year": [
     { "name": "1910", "context": "Geburtsjahr Django Reinhardts" },
     {
@@ -120,7 +120,7 @@
       "context": "Djangos Auftritt in Paris und Einfluss in der Jazzszene"
     }
   ],
-  "era": [
+  "historical_period": [
     {
       "name": "Gypsy Jazz",
       "context": "von Django Reinhardt geschaffenes Jazz Subgenre"
@@ -175,7 +175,7 @@
     },
     { "name": "Italien", "context": "Reiseort der Familie Reinhardt vor Paris" }
   ],
-  "sub_genre": [
+  "music_genre": [
     { "name": "Gypsy Jazz", "context": "Djangos eigenschaffener Stil" },
     {
       "name": "Jazz Manouche",
@@ -186,7 +186,7 @@
       "context": "Jazzstil, der das Interesse an Gypsy Jazz verdrängt"
     }
   ],
-  "instrument": [
+  "musical_instrument": [
     { "name": "Gitarre", "context": "Djangos Hauptinstrument" },
     {
       "name": "Geige",

--- a/episodes/tests/test_extract.py
+++ b/episodes/tests/test_extract.py
@@ -85,9 +85,9 @@ class ExtractorBuildSchemaTests(TestCase):
             self.assertIn(et.key, inner["required"])
 
         # Check one property structure
-        artist_prop = inner["properties"]["musician"]
-        self.assertEqual(artist_prop["type"], ["array", "null"])
-        item = artist_prop["items"]
+        musician_prop = inner["properties"]["musician"]
+        self.assertEqual(musician_prop["type"], ["array", "null"])
+        item = musician_prop["items"]
         self.assertIn("name", item["properties"])
         self.assertIn("context", item["properties"])
         self.assertFalse(item["additionalProperties"])

--- a/episodes/tests/test_extract.py
+++ b/episodes/tests/test_extract.py
@@ -33,7 +33,7 @@ class ExtractorBuildPromptTests(TestCase):
         prompt = build_system_prompt("de")
         self.assertIn("German", prompt)
         self.assertIn("entity extractor", prompt)
-        self.assertIn("Artist", prompt)
+        self.assertIn("Musician", prompt)
 
     def test_build_system_prompt_without_language(self):
         from episodes.extractor import build_system_prompt
@@ -55,7 +55,7 @@ class ExtractorBuildPromptTests(TestCase):
         EntityType.objects.filter(key="role").update(is_active=False)
         prompt = build_system_prompt("")
         self.assertNotIn("Role", prompt)
-        self.assertIn("Artist", prompt)
+        self.assertIn("Musician", prompt)
 
     def test_system_prompt_says_excerpt(self):
         from episodes.extractor import build_system_prompt
@@ -85,7 +85,7 @@ class ExtractorBuildSchemaTests(TestCase):
             self.assertIn(et.key, inner["required"])
 
         # Check one property structure
-        artist_prop = inner["properties"]["artist"]
+        artist_prop = inner["properties"]["musician"]
         self.assertEqual(artist_prop["type"], ["array", "null"])
         item = artist_prop["items"]
         self.assertIn("name", item["properties"])
@@ -102,29 +102,29 @@ class ExtractEntitiesTests(TestCase):
     """Tests for the extract_entities task function."""
 
     SAMPLE_ENTITIES = {
-        "artist": [
+        "musician": [
             {"name": "Miles Davis", "context": "discussed his trumpet style"},
         ],
-        "band": None,
+        "musical_group": None,
         "album": [
             {"name": "Kind of Blue", "context": "landmark album"},
         ],
-        "composition": None,
-        "venue": None,
+        "composed_musical_work": None,
+        "music_venue": None,
         "recording_session": None,
-        "label": [
+        "record_label": [
             {"name": "Columbia Records", "context": "released Kind of Blue"},
         ],
         "year": [
             {"name": "1959", "context": "year Kind of Blue was released"},
         ],
-        "era": None,
+        "historical_period": None,
         "city": None,
         "country": None,
-        "sub_genre": [
+        "music_genre": [
             {"name": "Modal Jazz", "context": "genre of Kind of Blue"},
         ],
-        "instrument": [
+        "musical_instrument": [
             {"name": "Trumpet", "context": "Miles Davis instrument"},
         ],
         "role": None,

--- a/episodes/tests/test_resolve.py
+++ b/episodes/tests/test_resolve.py
@@ -105,7 +105,7 @@ class ResolveEntitiesTests(TestCase):
         from episodes.resolver import resolve_entities
 
         # Pre-create an existing entity
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis"
         )
@@ -124,7 +124,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet player"},
             ],
         }
@@ -157,7 +157,7 @@ class ResolveEntitiesTests(TestCase):
         """Some matches, some new."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis"
         )
@@ -182,7 +182,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
                 {"name": "John Coltrane", "context": "saxophone"},
             ],
@@ -216,12 +216,12 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_chunk1 = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "early career"},
             ],
         }
         entities_chunk2 = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "later work"},
             ],
         }
@@ -254,7 +254,7 @@ class ResolveEntitiesTests(TestCase):
         """Multiple chunks with same entity type -> one resolution call with unique names."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis"
         )
@@ -279,12 +279,12 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_chunk1 = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
             ],
         }
         entities_chunk2 = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "bandleader"},
                 {"name": "John Coltrane", "context": "saxophone"},
             ],
@@ -321,7 +321,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "instrument": [
+            "musical_instrument": [
                 {"name": "Saxophon", "context": "German spelling"},
             ],
         }
@@ -332,7 +332,7 @@ class ResolveEntitiesTests(TestCase):
         )
         self._create_chunk(episode, index=0, entities_json=entities_json)
 
-        instrument_type = _get_entity_type("instrument")
+        instrument_type = _get_entity_type("musical_instrument")
 
         # First episode — no existing entities, so created directly with extracted name
         with patch("episodes.signals.async_task"):
@@ -358,7 +358,7 @@ class ResolveEntitiesTests(TestCase):
             status=Episode.Status.RESOLVING,
         )
         self._create_chunk(episode2, index=0, entities_json={
-            "instrument": [
+            "musical_instrument": [
                 {"name": "Saxophone", "context": "English spelling"},
             ],
         })
@@ -383,8 +383,8 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": None,
-            "band": None,
+            "musician": None,
+            "musical_group": None,
         }
 
         episode = self._create_episode(
@@ -409,7 +409,7 @@ class ResolveEntitiesTests(TestCase):
         """LLM returns matched_entity_id=None but canonical_name already exists -> reuse entity."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Django Reinhardt"
         )
@@ -428,7 +428,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Django Reinhardt", "context": "jazz guitarist"},
             ],
         }
@@ -495,7 +495,7 @@ class ResolveEntitiesTests(TestCase):
         from episodes.resolver import resolve_entities
 
         # Pre-create an existing entity so LLM call happens
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         Entity.objects.create(entity_type=artist_type, name="Miles Davis")
 
         mock_provider = MagicMock()
@@ -503,7 +503,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
             ],
         }
@@ -618,7 +618,7 @@ class ResolveEntitiesTests(TestCase):
         """Wikidata candidates are passed to the LLM and wikidata_id is saved."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis"
         )
@@ -637,7 +637,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
             ],
         }
@@ -675,7 +675,7 @@ class ResolveEntitiesTests(TestCase):
         """Entity with matching wikidata_id in DB is reused."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis", wikidata_id="Q93341"
         )
@@ -694,7 +694,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "M. Davis", "context": "trumpet"},
             ],
         }
@@ -733,7 +733,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
             ],
         }
@@ -778,7 +778,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
                 {"name": "John Coltrane", "context": "saxophone"},
             ],
@@ -818,7 +818,7 @@ class ResolveEntitiesTests(TestCase):
         """LLM omits a name when existing entities present — fallback creates it."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis"
         )
@@ -838,7 +838,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
                 {"name": "John Coltrane", "context": "saxophone"},
             ],
@@ -867,7 +867,7 @@ class ResolveEntitiesTests(TestCase):
         """Two extracted names resolve to the same entity in the same chunk — no duplicate mention."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("artist")
+        artist_type = _get_entity_type("musician")
         existing = Entity.objects.create(
             entity_type=artist_type, name="Miles Davis"
         )
@@ -894,7 +894,7 @@ class ResolveEntitiesTests(TestCase):
 
         # Both names appear in the same chunk
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet legend"},
                 {"name": "Miles", "context": "short form"},
             ],
@@ -928,7 +928,7 @@ class ResolveEntitiesTests(TestCase):
         mock_factory.return_value = mock_provider
 
         entities_json = {
-            "artist": [
+            "musician": [
                 {"name": "Miles Davis", "context": "trumpet"},
             ],
         }

--- a/episodes/tests/test_resolve.py
+++ b/episodes/tests/test_resolve.py
@@ -90,7 +90,7 @@ class ResolveEntitiesTests(TestCase):
         # No LLM call needed when no existing entities and no Wikidata candidates
         mock_provider.structured_extract.assert_not_called()
 
-        # 59 entities from fixture (3 null types: album, recording_session, label)
+        # 59 entities from fixture (3 null types: album, recording_session, record_label)
         self.assertEqual(Entity.objects.count(), 59)
         self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 59)
 
@@ -105,9 +105,9 @@ class ResolveEntitiesTests(TestCase):
         from episodes.resolver import resolve_entities
 
         # Pre-create an existing entity
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis"
+            entity_type=musician_type, name="Miles Davis"
         )
 
         mock_provider = MagicMock()
@@ -141,9 +141,9 @@ class ResolveEntitiesTests(TestCase):
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.EMBEDDING)
 
-        # Still only 1 artist entity
+        # Still only 1 musician entity
         self.assertEqual(
-            Entity.objects.filter(entity_type=artist_type).count(), 1
+            Entity.objects.filter(entity_type=musician_type).count(), 1
         )
         # Mention was created with chunk FK
         mention = EntityMention.objects.get(episode=episode)
@@ -157,9 +157,9 @@ class ResolveEntitiesTests(TestCase):
         """Some matches, some new."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis"
+            entity_type=musician_type, name="Miles Davis"
         )
 
         mock_provider = MagicMock()
@@ -200,9 +200,9 @@ class ResolveEntitiesTests(TestCase):
         episode.refresh_from_db()
         self.assertEqual(episode.status, Episode.Status.EMBEDDING)
 
-        # 2 artist entities: existing Miles + new Coltrane
+        # 2 musician entities: existing Miles + new Coltrane
         self.assertEqual(
-            Entity.objects.filter(entity_type=artist_type).count(), 2
+            Entity.objects.filter(entity_type=musician_type).count(), 2
         )
         self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 2)
 
@@ -254,9 +254,9 @@ class ResolveEntitiesTests(TestCase):
         """Multiple chunks with same entity type -> one resolution call with unique names."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis"
+            entity_type=musician_type, name="Miles Davis"
         )
 
         mock_provider = MagicMock()
@@ -300,7 +300,7 @@ class ResolveEntitiesTests(TestCase):
         with patch("episodes.signals.async_task"):
             resolve_entities(episode.pk)
 
-        # Only 1 LLM call (one entity type: artist)
+        # Only 1 LLM call (one entity type: musician)
         self.assertEqual(mock_provider.structured_extract.call_count, 1)
 
         # Unique names sent to resolution
@@ -409,9 +409,9 @@ class ResolveEntitiesTests(TestCase):
         """LLM returns matched_entity_id=None but canonical_name already exists -> reuse entity."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Django Reinhardt"
+            entity_type=musician_type, name="Django Reinhardt"
         )
 
         mock_provider = MagicMock()
@@ -447,7 +447,7 @@ class ResolveEntitiesTests(TestCase):
 
         # Should reuse existing entity, not crash
         self.assertEqual(
-            Entity.objects.filter(entity_type=artist_type).count(), 1
+            Entity.objects.filter(entity_type=musician_type).count(), 1
         )
         mention = EntityMention.objects.get(episode=episode)
         self.assertEqual(mention.entity, existing)
@@ -495,8 +495,8 @@ class ResolveEntitiesTests(TestCase):
         from episodes.resolver import resolve_entities
 
         # Pre-create an existing entity so LLM call happens
-        artist_type = _get_entity_type("musician")
-        Entity.objects.create(entity_type=artist_type, name="Miles Davis")
+        musician_type = _get_entity_type("musician")
+        Entity.objects.create(entity_type=musician_type, name="Miles Davis")
 
         mock_provider = MagicMock()
         mock_provider.structured_extract.side_effect = Exception("API error")
@@ -618,9 +618,9 @@ class ResolveEntitiesTests(TestCase):
         """Wikidata candidates are passed to the LLM and wikidata_id is saved."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis"
+            entity_type=musician_type, name="Miles Davis"
         )
 
         mock_provider = MagicMock()
@@ -675,9 +675,9 @@ class ResolveEntitiesTests(TestCase):
         """Entity with matching wikidata_id in DB is reused."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis", wikidata_id="Q93341"
+            entity_type=musician_type, name="Miles Davis", wikidata_id="Q93341"
         )
 
         mock_provider = MagicMock()
@@ -710,7 +710,7 @@ class ResolveEntitiesTests(TestCase):
                 resolve_entities(episode.pk)
 
         # Should match existing entity by wikidata_id
-        self.assertEqual(Entity.objects.filter(entity_type=artist_type).count(), 1)
+        self.assertEqual(Entity.objects.filter(entity_type=musician_type).count(), 1)
         mention = EntityMention.objects.get(episode=episode)
         self.assertEqual(mention.entity, existing)
 
@@ -818,9 +818,9 @@ class ResolveEntitiesTests(TestCase):
         """LLM omits a name when existing entities present — fallback creates it."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis"
+            entity_type=musician_type, name="Miles Davis"
         )
 
         mock_provider = MagicMock()
@@ -858,7 +858,7 @@ class ResolveEntitiesTests(TestCase):
         self.assertEqual(episode.status, Episode.Status.EMBEDDING)
 
         # Miles matched, Coltrane created via fallback
-        self.assertEqual(Entity.objects.filter(entity_type=artist_type).count(), 2)
+        self.assertEqual(Entity.objects.filter(entity_type=musician_type).count(), 2)
         self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 2)
 
     @patch("episodes.resolver._fetch_wikidata_candidates", return_value={})
@@ -867,9 +867,9 @@ class ResolveEntitiesTests(TestCase):
         """Two extracted names resolve to the same entity in the same chunk — no duplicate mention."""
         from episodes.resolver import resolve_entities
 
-        artist_type = _get_entity_type("musician")
+        musician_type = _get_entity_type("musician")
         existing = Entity.objects.create(
-            entity_type=artist_type, name="Miles Davis"
+            entity_type=musician_type, name="Miles Davis"
         )
 
         mock_provider = MagicMock()
@@ -913,7 +913,7 @@ class ResolveEntitiesTests(TestCase):
         self.assertEqual(episode.status, Episode.Status.EMBEDDING)
 
         # Only 1 entity, 1 mention (deduped by entity+chunk)
-        self.assertEqual(Entity.objects.filter(entity_type=artist_type).count(), 1)
+        self.assertEqual(Entity.objects.filter(entity_type=musician_type).count(), 1)
         self.assertEqual(EntityMention.objects.filter(episode=episode).count(), 1)
         mention = EntityMention.objects.get(episode=episode)
         self.assertEqual(mention.entity, existing)


### PR DESCRIPTION
## Summary

- Rename 8 entity type keys, names, and descriptions in `initial_entity_types.yaml` to match their official Wikidata labels (e.g., `artist` -> `musician`, `band` -> `musical_group`, `label` -> `record_label`)
- Fix incorrect Wikidata Q-ID for `recording_session`: was Q81091849 (a galaxy in Virgo), now Q98216532 ("period of time devoted to recording music in a studio")
- Propagate key renames across test fixtures, test data, and README

**Note:** This project has not been released yet. There are no existing installs to migrate — a fresh `migrate` + `load_entity_types` is the only supported path.

## Test plan

- [x] All 150 tests pass (`uv run python manage.py test`)
- [ ] Fresh DB migration seeds correct entity type names
- [ ] Entity types display correctly in Django admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)