### PR TITLE
Clarify Extract and Resolve README sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2026-03-17
+
+### Changed
+
+- Clarify Extract and Resolve README sections — rewrite pipeline steps 7 and 8 with NER/NEL labels, concrete example tables, and two-phase design rationale — [plan](doc/plans/clarify-extract-resolve-readme.md), [feature](doc/features/clarify-extract-resolve-readme.md), [planning session](doc/sessions/2026-03-17-clarify-extract-resolve-readme-planning-session.md), [implementation session](doc/sessions/2026-03-17-clarify-extract-resolve-readme-implementation-session.md)
+
 ## 2026-03-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Split transcript into ~150-word chunks along Whisper segment boundaries, with 1-
 
 Runs **per chunk**: each chunk is sent to the LLM independently, which returns the entity names and types it finds. This is a surface-level task — the LLM only needs the chunk's text to spot mentions. Results are stored as raw JSON in `Chunk.entities_json`.
 
-At this stage, no database records are created and no deduplication happens. The same entity may appear under different surface forms across chunks (e.g., "Bird" in chunk 3, "Charlie Parker" in chunk 12).
+At this stage, no `Entity` or `EntityMention` records are created and no deduplication happens. The same entity may appear under different surface forms across chunks (e.g., "Bird" in chunk 3, "Charlie Parker" in chunk 12).
 
-**Example** — given a chunk containing *"Bird played trumpet at Birdland alongside Dizzy Gillespie"*, extraction produces:
+**Example** — given a chunk containing *"Bird played at Birdland alongside Dizzy Gillespie"*, extraction produces:
 
 | Mention | Type |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -78,17 +78,49 @@ Split transcript into ~150-word chunks along Whisper segment boundaries, with 1-
 
 #### 7. 🔍 Extract entities (status: `extracting`)
 
-LLM-based entity extraction runs **per chunk**, linking each entity mention to the specific chunk (and thus timestamp) where it appeared. Entity types (musician, musical group, album, composed musical work, music venue, recording session, record label, year, historical period, city, country, music genre, musical instrument, role) are stored in the database and managed via Django admin. Each entity type has a **Wikidata class Q-ID** (e.g., Q639669 for "musician") for candidate lookup during resolution. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with:
+**Named Entity Recognition (NER)** — identifies entity mentions in the transcript text.
+
+Runs **per chunk**: each chunk is sent to the LLM independently, which returns the entity names and types it finds. This is a surface-level task — the LLM only needs the chunk's text to spot mentions. Results are stored as raw JSON in `Chunk.entities_json`.
+
+At this stage, no database records are created and no deduplication happens. The same entity may appear under different surface forms across chunks (e.g., "Bird" in chunk 3, "Charlie Parker" in chunk 12).
+
+**Example** — given a chunk containing *"Bird played trumpet at Birdland alongside Dizzy Gillespie"*, extraction produces:
+
+| Mention | Type |
+|---|---|
+| Bird | musician |
+| Birdland | music venue |
+| Dizzy Gillespie | musician |
+
+**Entity types** (musician, musical group, album, composed musical work, music venue, recording session, record label, year, historical period, city, country, music genre, musical instrument, role) are stored in the database and managed via Django admin. Each entity type has a **Wikidata class Q-ID** (e.g., Q639669 for "musician") used for candidate lookup during resolution. An initial set of 14 types is defined in [`episodes/initial_entity_types.yaml`](episodes/initial_entity_types.yaml) — load them with:
 
 ```
 uv run python manage.py load_entity_types
 ```
 
-New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity). Raw extraction results are stored in `Chunk.entities_json`.
+New types can be added through Django admin; existing types can be deactivated (set `is_active = False`) to exclude them from future extractions without deleting historical data. Types that have existing entities cannot be deleted (protected by referential integrity).
 
 #### 8. 🧩 Resolve entities (status: `resolving`)
 
-Aggregates unique entity names across all chunks, then resolves once per entity type against existing DB records using LLM-based fuzzy matching to prevent duplicates. During resolution, **Wikidata candidate lookup** searches for matching entities by name and type, presenting candidates (with Q-IDs and descriptions) to the LLM for confirmation. The LLM picks the best Wikidata match or returns null if none apply. Matched entities receive a `wikidata_id` for canonical identification. Creates canonical entity records and `EntityMention` records per (entity, chunk) pair, preserving provenance. Search Wikidata from the CLI with:
+**Entity Linking (NEL)** — maps extracted mentions to canonical entity records, deduplicating across chunks.
+
+Aggregates all extracted names across every chunk, then resolves **once per entity type** using LLM-based fuzzy matching against two sources:
+
+1. **Existing DB records** — prevents duplicates when the same entity was seen in a previous episode.
+2. **Wikidata candidates** — searches by name and type, presenting candidates (with Q-IDs and descriptions) to the LLM for confirmation. Matched entities receive a `wikidata_id` for canonical identification.
+
+**Example** — continuing from the extract step, suppose the episode's chunks collectively mention "Bird", "Charlie Parker", "Yardbird", and "Dizzy Gillespie":
+
+| Extracted mentions | Resolved to (canonical entity) | Wikidata ID |
+|---|---|---|
+| Bird, Charlie Parker, Yardbird | Charlie Parker | Q103767 |
+| Dizzy Gillespie | Dizzy Gillespie | Q49575 |
+
+All three surface forms collapse into a single `Entity` record for Charlie Parker. An `EntityMention` is created for each (entity, chunk) pair, preserving which chunks mentioned the entity and the context of each mention.
+
+This two-phase design (extract then resolve) is intentional: extraction is cheap and parallelizable per chunk, while resolution requires cross-chunk aggregation and knowledge base lookups. It also allows re-running resolution independently — e.g., after improving matching logic — without re-extracting.
+
+Search Wikidata from the CLI with:
 
 ```
 uv run python manage.py lookup_entity "Miles Davis"

--- a/doc/features/clarify-extract-resolve-readme.md
+++ b/doc/features/clarify-extract-resolve-readme.md
@@ -1,0 +1,28 @@
+# Feature: Clarify Extract and Resolve README Sections
+
+## Problem
+
+The README descriptions for pipeline steps 7 (Extract entities) and 8 (Resolve entities) were dense single paragraphs that didn't clearly explain what each step does, why they're separate, or how they relate to standard NLP concepts (NER and NEL). Readers had to infer the two-phase design rationale from implementation details.
+
+## Changes
+
+- **Step 7 rewritten** — added NER label, explained per-chunk processing with no DB records created, added example table showing entity extraction from a sample sentence, moved `Chunk.entities_json` mention earlier in the text
+- **Step 8 rewritten** — added NEL label, broke resolution into numbered list (DB matching + Wikidata candidates), added example table showing surface forms collapsing into canonical entities, added rationale paragraph explaining the two-phase design
+
+## Key Parameters
+
+No tunable constants changed. Documentation-only change.
+
+## Verification
+
+```bash
+uv run python manage.py test   # No code changes, sanity check only
+```
+
+Review rendered markdown tables for correct formatting.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `README.md` | Rewrote steps 7 and 8 with NER/NEL labels, examples, and two-phase rationale |

--- a/doc/plans/clarify-extract-resolve-readme.md
+++ b/doc/plans/clarify-extract-resolve-readme.md
@@ -1,0 +1,34 @@
+# Plan: Clarify Extract and Resolve README sections
+
+## Context
+
+The README's pipeline steps 7 (Extract entities) and 8 (Resolve entities) are dense single-paragraph descriptions that don't clearly explain *what* each step does or *why* they're separate. We want to rewrite these sections to introduce NER/NEL concepts, add concrete examples, and explain the two-phase design — while keeping the existing code terminology ("extract", "extracting") unchanged.
+
+## Changes
+
+**File: `README.md`** — rewrite sections for steps 7 and 8 only.
+
+### Step 7: Extract entities
+- Add **NER** label and one-line description
+- Explain per-chunk processing and that no DB records are created
+- Add example table (Bird → musician, Birdland → music venue, Dizzy Gillespie → musician)
+- Keep entity types list with correct Wikidata-aligned names
+- Keep `load_entity_types` command block and admin notes
+- Move "Raw extraction results are stored in `Chunk.entities_json`" from end to earlier in the text
+
+### Step 8: Resolve entities
+- Add **NEL** label and one-line description
+- Break into numbered list: DB matching + Wikidata candidates
+- Add example table showing surface forms collapsing (Bird/Charlie Parker/Yardbird → Charlie Parker Q103767)
+- Add rationale paragraph for two-phase design
+- Keep `lookup_entity` CLI commands
+
+## Verification
+
+- Review the rendered markdown for correct table formatting
+- `uv run python manage.py test` — no code changes, but sanity check
+- Confirm no other README sections were affected
+
+## Files modified
+
+- `README.md` — steps 7 and 8 only

--- a/doc/sessions/2026-03-17-clarify-extract-resolve-readme-implementation-session.md
+++ b/doc/sessions/2026-03-17-clarify-extract-resolve-readme-implementation-session.md
@@ -1,0 +1,25 @@
+# Session: Clarify Extract and Resolve README — Implementation
+
+**Date:** 2026-03-17
+
+## Summary
+
+Implemented the planned README rewrite for pipeline steps 7 and 8. The README changes were already applied during the planning session, so this session focused on creating the documentation artifacts (plan, feature doc, session transcripts, changelog) and committing.
+
+## Conversation
+
+### User
+Asked to implement the plan for clarifying the Extract and Resolve README sections.
+
+### Assistant
+Checked the working tree — the README changes from the planning session were already present in the diff. Verified the content matched the agreed-upon plan: NER/NEL labels, example tables, per-chunk explanation, two-phase rationale paragraph, and preserved CLI command blocks.
+
+Created documentation:
+- `doc/plans/clarify-extract-resolve-readme.md`
+- `doc/features/clarify-extract-resolve-readme.md`
+- `doc/sessions/2026-03-17-clarify-extract-resolve-readme-planning-session.md`
+- `doc/sessions/2026-03-17-clarify-extract-resolve-readme-implementation-session.md`
+
+Updated `CHANGELOG.md` with entry under 2026-03-17.
+
+Created branch `docs/clarify-extract-resolve-readme`, committed all changes, and opened a PR.

--- a/doc/sessions/2026-03-17-clarify-extract-resolve-readme-planning-session.md
+++ b/doc/sessions/2026-03-17-clarify-extract-resolve-readme-planning-session.md
@@ -1,0 +1,35 @@
+# Session: Clarify Extract and Resolve README — Planning
+
+**Session ID:** 3ce31107-6e3f-4071-9b59-a054e2a236a3
+**Date:** 2026-03-17
+
+## Summary
+
+Planned a rewrite of README pipeline steps 7 (Extract entities) and 8 (Resolve entities) to introduce NER/NEL terminology, add concrete examples, and explain the two-phase design rationale. Considered renaming "extract" to "recognize" across the codebase but decided against it due to large blast radius (code, migrations, env vars, tests).
+
+## Conversation
+
+### User
+Asked to review and improve the README sections for steps 7 and 8 of the pipeline.
+
+### Assistant
+Read the current README sections. Proposed a rewrite that:
+- Adds NER/NEL labels as bold subtitles
+- Breaks dense paragraphs into structured sections
+- Adds example tables for both steps (extraction from sample text, surface form collapse during resolution)
+- Adds a rationale paragraph for the two-phase design
+- Moves `Chunk.entities_json` mention earlier in step 7
+
+Applied the changes to the working tree.
+
+### User
+Asked whether we should rename "extract" to "recognize" in code to align with NER terminology.
+
+### Assistant
+Analyzed the blast radius: the term "extract" appears in status values (`extracting`), model fields, provider classes, signal handlers, management commands, tests, and env vars. Renaming would touch 20+ files, require a migration, and break the `RAGTIME_EXTRACTION_*` env var prefix. Recommended keeping "extract" in code and using the NER/NEL labels only in documentation.
+
+### User
+Agreed. Asked to proceed with the documentation-only approach.
+
+### Assistant
+Created the implementation plan and saved it to `doc/plans/clarify-extract-resolve-readme.md`.


### PR DESCRIPTION
## Summary

- Rewrite pipeline steps 7 (Extract entities) and 8 (Resolve entities) in README with NER/NEL labels, concrete example tables, and two-phase design rationale
- Documentation-only change — no code modifications

## Test plan

- [x] All 150 tests pass (`uv run python manage.py test`)
- [x] Review rendered markdown tables for correct formatting
- [x] Confirm no other README sections were affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)