### PR TITLE
Fix doc file header ordering and clarify AGENTS.md format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ When a plan is accepted, save it to `doc/plans/`, one Markdown file per plan, wi
 
 Save the planning session transcript to `doc/sessions/` with a filename ending in `-planning-session.md`. Each transcript must include:
 
-- **Session ID** — the actual Claude Code session UUID (e.g., `a150a5a3-218f-44b4-a02b-cf90912619d7`), at the top of the file. Do not use placeholders like "current session" or worktree names — retrieve the real UUID. Use `unavailable` only when the UUID cannot be recovered from session logs.
+- **Session ID** — the actual Claude Code session UUID (e.g., `a150a5a3-218f-44b4-a02b-cf90912619d7`), immediately after the `# Title`. Do not use placeholders like "current session" or worktree names — retrieve the real UUID. Use `unavailable` only when the UUID cannot be recovered from session logs.
 - **Summary** — a short `## Summary` describing what was planned.
 - **Detailed conversation** — record the actual conversation as a sequence of `### User` and `### Assistant` sections using verbatim text. Include the assistant's reasoning steps (e.g. what it explored, what alternatives it considered, why it chose a particular approach).
 
@@ -82,13 +82,11 @@ Feature documentation lives in `doc/features/`, one Markdown file per feature or
 - **Verification** — how to test the change on-device (deploy command + expected behaviour).
 - **Files modified** — list of touched files with a one-line summary of each change.
 
-Save the implementation session transcript to `doc/sessions/` with a filename ending in `-implementation-session.md`. Same format as the planning transcript (session ID, summary, detailed conversation with reasoning steps).
+Save the implementation session transcript to `doc/sessions/` with a filename ending in `-implementation-session.md`. Same format as the planning session (session ID, summary, verbatim conversation with reasoning steps).
 
-All doc files (features, plans, and session transcripts) must include `**Session ID:**` (session transcripts) and `**Date:** YYYY-MM-DD` metadata lines near the top of the file, before any `##` section, following the reference transcript format.
+Every doc file must start with a `# Title` on the very first line. Metadata lines (`**Date:** YYYY-MM-DD` for all doc types; `**Session ID:**` for session transcripts) go immediately after the title, before any `## Section`. Never place metadata above the title. See the reference transcript for the canonical format.
 
 Keep prose concise. Prefer tables and lists over long paragraphs. Use code blocks for CLI commands and signal-flow diagrams.
-
-See `doc/sessions/2026-03-10-ci-github-actions.md` as the reference format for transcripts.
 
 ### Changelog & env vars
 

--- a/doc/features/2026-03-20-readme-split.md
+++ b/doc/features/2026-03-20-readme-split.md
@@ -1,6 +1,6 @@
-**Date:** 2026-03-20
-
 # Feature: Split README into root overview + doc/README.md
+
+**Date:** 2026-03-20
 
 ## Problem
 

--- a/doc/plans/2026-03-20-readme-split.md
+++ b/doc/plans/2026-03-20-readme-split.md
@@ -1,6 +1,6 @@
-**Date:** 2026-03-20
-
 # Plan: Split README into root overview + doc/README.md
+
+**Date:** 2026-03-20
 
 ## Context
 

--- a/doc/sessions/2026-03-20-readme-split-implementation-session.md
+++ b/doc/sessions/2026-03-20-readme-split-implementation-session.md
@@ -1,7 +1,7 @@
+# README Split — Implementation Session
+
 **Session ID:** aa080a4f-3b10-4a71-baad-dd4170a334ac
 **Date:** 2026-03-20
-
-# README Split — Implementation Session
 
 ## Summary
 

--- a/doc/sessions/2026-03-20-readme-split-planning-session.md
+++ b/doc/sessions/2026-03-20-readme-split-planning-session.md
@@ -1,7 +1,7 @@
+# README Split — Planning Session
+
 **Session ID:** a9ed7a68-194f-46f8-a9f7-57acad62df15
 **Date:** 2026-03-20
-
-# README Split — Planning Session
 
 ## Summary
 


### PR DESCRIPTION
## Summary

- **Fix 4 doc files** from the March 20 readme-split work where metadata (`**Date:**`, `**Session ID:**`) was placed above the `# Title` heading — reordered to title-first
- **Clarify AGENTS.md** format rules: explicit statement that every doc file must start with `# Title` on line 1, with metadata immediately after — replacing the ambiguous "near the top of the file" wording

## Files changed

| File | Change |
|---|---|
| `AGENTS.md` | Tightened wording on lines 71 and 87 |
| `doc/plans/2026-03-20-readme-split.md` | Moved title above date |
| `doc/features/2026-03-20-readme-split.md` | Moved title above date |
| `doc/sessions/2026-03-20-readme-split-implementation-session.md` | Moved title above session ID + date |
| `doc/sessions/2026-03-20-readme-split-planning-session.md` | Moved title above session ID + date |

## Test plan

- [x] Verify all doc files under `doc/plans/`, `doc/features/`, `doc/sessions/` start with `# Title` on line 1
- [x] Confirm AGENTS.md format rules are clear and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)