### PR TITLE
Fix session transcript metadata Markdown rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Feature documentation lives in `doc/features/`, one Markdown file per feature or
 
 Save the implementation session transcript to `doc/sessions/`, with a `YYYY-MM-DD-` date prefix and a filename ending in `-implementation-session.md` (e.g., `2026-03-15-my-feature-implementation-session.md`). Same format as the planning session (session ID, summary, verbatim conversation with reasoning steps). The implementation transcript must include all interactions up to and including PR review feedback and any follow-up changes made after the PR is created.
 
-Every doc file must start with a `# Title` on the very first line. Metadata lines go immediately after the title, before any `## Section`: first `**Date:** YYYY-MM-DD` (all doc types), then `**Session ID:**` (session transcripts only). Never place metadata above the title.
+Every doc file must start with a `# Title` on the very first line. Metadata lines go immediately after the title, before any `## Section`: first `**Date:** YYYY-MM-DD` (all doc types), then `**Session ID:**` (session transcripts only). Never place metadata above the title. Separate each metadata line with a blank line so they render as distinct paragraphs in Markdown (e.g., a blank line between `**Date:**` and `**Session ID:**`).
 
 Keep prose concise. Prefer tables and lists over long paragraphs. Use code blocks for CLI commands and signal-flow diagrams.
 

--- a/doc/sessions/2026-03-09-step-01-submit-episode-implementation-session.md
+++ b/doc/sessions/2026-03-09-step-01-submit-episode-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 1 — Submit Episode
 
 **Date:** 2026-03-09
+
 **Session ID:** da0710ab-70ef-4477-b261-c7844e6a9175
 
 ## Summary

--- a/doc/sessions/2026-03-09-step-02-dedup-implementation-session.md
+++ b/doc/sessions/2026-03-09-step-02-dedup-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 2 — Dedup Verification
 
 **Date:** 2026-03-09
+
 **Session ID:** b1de5f21-0ff5-457b-a7de-9810631aebbe
 
 ## Summary

--- a/doc/sessions/2026-03-09-step-03-scrape-implementation-session.md
+++ b/doc/sessions/2026-03-09-step-03-scrape-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 3 — Scrape
 
 **Date:** 2026-03-09
+
 **Session ID:** 2bf6969f-4284-41f0-b8f2-0e2ed93eb4b4
 
 ## Summary

--- a/doc/sessions/2026-03-09-step-04-05-download-resize-implementation-session.md
+++ b/doc/sessions/2026-03-09-step-04-05-download-resize-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Steps 4 & 5 — Download & Resize Audio
 
 **Date:** 2026-03-09
+
 **Session ID:** 24f89e53-e785-4f37-a0bb-74b34206ac38
 
 ## Summary

--- a/doc/sessions/2026-03-10-ci-github-actions-implementation-session.md
+++ b/doc/sessions/2026-03-10-ci-github-actions-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: CI — GitHub Actions Workflow + README Badges
 
 **Date:** 2026-03-10
+
 **Session ID:** 2b9f6484-833b-46af-8583-5caa2a8b3e13
 
 ## Summary

--- a/doc/sessions/2026-03-11-fix-summarization-language-implementation-session.md
+++ b/doc/sessions/2026-03-11-fix-summarization-language-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Fix Summarization Episode Language
 
 **Date:** 2026-03-11
+
 **Session ID:** 59775a93-7de0-4f8a-9dec-c7feb45a5931
 
 ## Summary

--- a/doc/sessions/2026-03-11-step-06-transcribe-implementation-session.md
+++ b/doc/sessions/2026-03-11-step-06-transcribe-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 6 — Transcribe
 
 **Date:** 2026-03-11
+
 **Session ID:** 1af1a874-33e0-40e1-9ef1-d77efa05dd05
 
 ## Summary

--- a/doc/sessions/2026-03-11-step-07-summarize-implementation-session.md
+++ b/doc/sessions/2026-03-11-step-07-summarize-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 7 — Summarize
 
 **Date:** 2026-03-11
+
 **Session ID:** 1afe9154-b94c-4c29-ac27-aa97c3a54e67
 
 ## Summary

--- a/doc/sessions/2026-03-13-manage-py-configure-implementation-session.md
+++ b/doc/sessions/2026-03-13-manage-py-configure-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: manage.py configure — Implementation
 
 **Date:** 2026-03-13
+
 **Session ID:** 3cb9e358-6f56-4fae-9d4c-8bc5a933756a
 
 ## Summary

--- a/doc/sessions/2026-03-13-manage-py-configure-planning-session.md
+++ b/doc/sessions/2026-03-13-manage-py-configure-planning-session.md
@@ -1,6 +1,7 @@
 # Session: manage.py configure — Planning
 
 **Date:** 2026-03-13
+
 **Session ID:** 9a0dcfdd-1c99-4928-ad51-695753dfb44d
 
 ## Summary

--- a/doc/sessions/2026-03-13-refactor-episode-tests-implementation-session.md
+++ b/doc/sessions/2026-03-13-refactor-episode-tests-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Refactor Episode Tests into a Test Package
 
 **Date:** 2026-03-13
+
 **Session ID:** 1150057e-7f65-4b47-a01c-d8ff4441b6a8
 
 ## Summary

--- a/doc/sessions/2026-03-13-rename-scraping-provider-implementation-session.md
+++ b/doc/sessions/2026-03-13-rename-scraping-provider-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — Implementation
 
 **Date:** 2026-03-13
+
 **Session ID:** 3d8500b6-2d41-4f58-ad73-59ca8aa766ba
 
 ## Summary

--- a/doc/sessions/2026-03-13-rename-scraping-provider-planning-session.md
+++ b/doc/sessions/2026-03-13-rename-scraping-provider-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Rename RAGTIME_LLM_* → RAGTIME_SCRAPING_* — Planning
 
 **Date:** 2026-03-13
+
 **Session ID:** 75420318-d8a7-44a3-855c-0d067ea8cef2
 
 ## Summary

--- a/doc/sessions/2026-03-13-session-transcript-format-implementation-session.md
+++ b/doc/sessions/2026-03-13-session-transcript-format-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Update Session Transcript Format in AGENTS.md
 
 **Date:** 2026-03-13
+
 **Session ID:** 89eeda14-a7f4-4e7c-bc25-066f28181385
 
 ## Summary

--- a/doc/sessions/2026-03-13-step-08-extract-entities-implementation-session.md
+++ b/doc/sessions/2026-03-13-step-08-extract-entities-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 8 — Extract Entities
 
 **Date:** 2026-03-13
+
 **Session ID:** da971828-9b37-46fe-9338-a5d1cef9606e
 
 ## Summary

--- a/doc/sessions/2026-03-13-step-09-resolve-entities-implementation-session.md
+++ b/doc/sessions/2026-03-13-step-09-resolve-entities-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Step 9 — Resolve Entities — Implementation
 
 **Date:** 2026-03-13
+
 **Session ID:** 5b6f037b-ee16-40ac-aef1-d362a58cc52f
 
 ## Summary

--- a/doc/sessions/2026-03-13-step-09-resolve-entities-planning-session.md
+++ b/doc/sessions/2026-03-13-step-09-resolve-entities-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Step 9 — Resolve Entities — Planning
 
 **Date:** 2026-03-13
+
 **Session ID:** 09ef4d53-d8b5-48a3-8fb8-bd017e1499ee
 
 ## Summary

--- a/doc/sessions/2026-03-14-entity-types-to-db-implementation-session.md
+++ b/doc/sessions/2026-03-14-entity-types-to-db-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Entity Types to DB — Implementation
 
 **Date:** 2026-03-14
+
 **Session ID:** 0c231adc-aa44-431c-afb8-4ddcd9e5e5da
 
 ## Summary

--- a/doc/sessions/2026-03-14-entity-types-to-db-planning-session.md
+++ b/doc/sessions/2026-03-14-entity-types-to-db-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Entity Types to DB — Planning
 
 **Date:** 2026-03-14
+
 **Session ID:** 66a82ba2-f434-43d3-ad62-6aa697eb6421
 
 ## Summary

--- a/doc/sessions/2026-03-14-episode-duration-implementation-session.md
+++ b/doc/sessions/2026-03-14-episode-duration-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Episode Duration — Implementation
 
 **Date:** 2026-03-14
+
 **Session ID:** 83e8d60a-9faa-48cf-9575-93f7f115e1bf
 
 ## Summary

--- a/doc/sessions/2026-03-14-episode-duration-planning-session.md
+++ b/doc/sessions/2026-03-14-episode-duration-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Episode Duration — Planning
 
 **Date:** 2026-03-14
+
 **Session ID:** 7f339a4a-fc60-429d-a3a5-5a6acda9935c
 
 ## Summary

--- a/doc/sessions/2026-03-14-processing-status-tracking-implementation-session.md
+++ b/doc/sessions/2026-03-14-processing-status-tracking-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Processing Status Tracking — Implementation
 
 **Date:** 2026-03-14
+
 **Session ID:** b64c02cc-642e-4cfe-94e9-6d3e1d2bd549
 
 ## Summary

--- a/doc/sessions/2026-03-14-processing-status-tracking-planning-session.md
+++ b/doc/sessions/2026-03-14-processing-status-tracking-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Processing Status Tracking — Planning
 
 **Date:** 2026-03-14
+
 **Session ID:** ebcf8a85-6dd7-41a6-b9e6-707e1ea8cbbe
 
 ## Summary

--- a/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md
+++ b/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Adaptive Audio Resize Tiers — Implementation
 
 **Date:** 2026-03-15
+
 **Session ID:** 124bb45c-1851-4ccb-a20f-9289b26938d3
 
 ## Summary

--- a/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md
+++ b/doc/sessions/2026-03-15-adaptive-audio-resize-tiers-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Adaptive Audio Resize Tiers — Planning
 
 **Date:** 2026-03-15
+
 **Session ID:** f750c0ab-7ee3-4e9b-81ff-9bebac97db25
 
 ## Summary

--- a/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
+++ b/doc/sessions/2026-03-15-chunk-level-entity-extraction-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Chunk-level Entity Extraction — Implementation
 
 **Date:** 2026-03-15
+
 **Session ID:** 66396f5d-2329-4f7b-9cbe-ad108bbaa9cf
 
 ## Summary

--- a/doc/sessions/2026-03-15-chunk-level-entity-extraction-planning-session.md
+++ b/doc/sessions/2026-03-15-chunk-level-entity-extraction-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Chunk-level Entity Extraction — Planning
 
 **Date:** 2026-03-15
+
 **Session ID:** d8df4186-a362-415c-9d05-bc068bbd5fd0
 
 ## Summary

--- a/doc/sessions/2026-03-15-merge-resize-into-transcribe-implementation-session.md
+++ b/doc/sessions/2026-03-15-merge-resize-into-transcribe-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Merge Resize Step into Transcribe Step — Implementation
 
 **Date:** 2026-03-15
+
 **Session ID:** 878af4b2-dd47-4574-9456-ae54703feddc
 
 ## Summary

--- a/doc/sessions/2026-03-15-merge-resize-into-transcribe-planning-session.md
+++ b/doc/sessions/2026-03-15-merge-resize-into-transcribe-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Merge Resize Step into Transcribe Step — Planning
 
 **Date:** 2026-03-15
+
 **Session ID:** ab6c3b6c-4c8f-4c92-ada2-1c5485876d45
 
 ## Summary

--- a/doc/sessions/2026-03-15-readme-pipeline-subsections-implementation-session.md
+++ b/doc/sessions/2026-03-15-readme-pipeline-subsections-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: README Pipeline Subsections — Implementation
 
 **Date:** 2026-03-15
+
 **Session ID:** 5abc5ca8-8ee9-4b78-8875-7b1bef5b5d74
 
 ## Summary

--- a/doc/sessions/2026-03-15-readme-pipeline-subsections-planning-session.md
+++ b/doc/sessions/2026-03-15-readme-pipeline-subsections-planning-session.md
@@ -1,6 +1,7 @@
 # Session: README Pipeline Subsections — Planning
 
 **Date:** 2026-03-15
+
 **Session ID:** a25c155f-6751-4a1f-b711-5ad9f84f435e
 
 ## Summary

--- a/doc/sessions/2026-03-15-wikidata-integration-implementation-session.md
+++ b/doc/sessions/2026-03-15-wikidata-integration-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Wikidata Integration — Implementation
 
 **Date:** 2026-03-15
+
 **Session ID:** dcebca8f-2553-424d-8928-8671e16d269a
 
 ## Summary

--- a/doc/sessions/2026-03-15-wikidata-integration-planning-session.md
+++ b/doc/sessions/2026-03-15-wikidata-integration-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Wikidata Integration — Planning
 
 **Date:** 2026-03-15
+
 **Session ID:** 338ce28e-0518-499d-9202-0e280fe151bd
 
 ## Summary

--- a/doc/sessions/2026-03-16-langfuse-observability-implementation-session.md
+++ b/doc/sessions/2026-03-16-langfuse-observability-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Langfuse Observability — Implementation
 
 **Date:** 2026-03-16
+
 **Session ID:** e4195dc3-3f40-451f-a8dc-03086f34458e
 
 ## Summary

--- a/doc/sessions/2026-03-16-langfuse-observability-planning-session.md
+++ b/doc/sessions/2026-03-16-langfuse-observability-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Langfuse Observability — Planning
 
 **Date:** 2026-03-16
+
 **Session ID:** 0f60528e-6b16-41a5-b9d0-13c277121673
 
 ## Summary

--- a/doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md
+++ b/doc/sessions/2026-03-16-wikidata-entity-type-renames-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Rename Entity Type Keys to Match Wikidata Labels — Implementation
 
 **Date:** 2026-03-16
+
 **Session ID:** 244fc552-853c-485c-8f67-63ed21881f13
 
 ## Summary

--- a/doc/sessions/2026-03-16-wikidata-entity-type-renames-planning-session.md
+++ b/doc/sessions/2026-03-16-wikidata-entity-type-renames-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Rename Entity Type Keys to Match Wikidata Labels — Planning
 
 **Date:** 2026-03-16
+
 **Session ID:** 244fc552-853c-485c-8f67-63ed21881f13
 
 ## Summary

--- a/doc/sessions/2026-03-17-clarify-extract-resolve-readme-implementation-session.md
+++ b/doc/sessions/2026-03-17-clarify-extract-resolve-readme-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Clarify Extract and Resolve README — Implementation
 
 **Date:** 2026-03-17
+
 **Session ID:** a2ba7bc1-b12e-4f27-989a-cad6af5ed5ba
 
 ## Summary

--- a/doc/sessions/2026-03-17-clarify-extract-resolve-readme-planning-session.md
+++ b/doc/sessions/2026-03-17-clarify-extract-resolve-readme-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Clarify Extract and Resolve README — Planning
 
 **Date:** 2026-03-17
+
 **Session ID:** 3ce31107-6e3f-4071-9b59-a054e2a236a3
 
 ## Summary

--- a/doc/sessions/2026-03-18-decoupled-recovery-architecture-implementation-session.md
+++ b/doc/sessions/2026-03-18-decoupled-recovery-architecture-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Decoupled Recovery Architecture — Implementation
 
 **Date:** 2026-03-18
+
 **Session ID:** e024308c-acb7-4da0-86d2-783f84f07b60
 
 ## Summary

--- a/doc/sessions/2026-03-18-decoupled-recovery-architecture-planning-session.md
+++ b/doc/sessions/2026-03-18-decoupled-recovery-architecture-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Decoupled Recovery Architecture — Planning
 
 **Date:** 2026-03-18
+
 **Session ID:** d7842f79-ffa8-4b5c-aa5c-336122a4a70d
 
 ## Summary

--- a/doc/sessions/2026-03-19-agent-recovery-strategy-implementation-session.md
+++ b/doc/sessions/2026-03-19-agent-recovery-strategy-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Agent Recovery Strategy — Implementation
 
 **Date:** 2026-03-19
+
 **Session ID:** 92a11085-c37d-46dc-9439-48864cdaf996
 
 ## Summary

--- a/doc/sessions/2026-03-19-agent-recovery-strategy-planning-session.md
+++ b/doc/sessions/2026-03-19-agent-recovery-strategy-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Agent Recovery Strategy — Planning
 
 **Date:** 2026-03-19
+
 **Session ID:** a150a5a3-218f-44b4-a02b-cf90912619d7
 
 ## Summary

--- a/doc/sessions/2026-03-20-readme-split-implementation-session.md
+++ b/doc/sessions/2026-03-20-readme-split-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: README Split — Implementation
 
 **Date:** 2026-03-20
+
 **Session ID:** aa080a4f-3b10-4a71-baad-dd4170a334ac
 
 ## Summary

--- a/doc/sessions/2026-03-20-readme-split-planning-session.md
+++ b/doc/sessions/2026-03-20-readme-split-planning-session.md
@@ -1,6 +1,7 @@
 # Session: README Split — Planning
 
 **Date:** 2026-03-20
+
 **Session ID:** a9ed7a68-194f-46f8-a9f7-57acad62df15
 
 ## Summary

--- a/doc/sessions/2026-03-21-session-transcript-compliance-implementation-session.md
+++ b/doc/sessions/2026-03-21-session-transcript-compliance-implementation-session.md
@@ -1,6 +1,7 @@
 # Session: Session Transcript Compliance — Implementation
 
 **Date:** 2026-03-21
+
 **Session ID:** 29ed4bba-4c66-40af-9cc6-fd0ef675b941
 
 ## Summary

--- a/doc/sessions/2026-03-21-session-transcript-compliance-planning-session.md
+++ b/doc/sessions/2026-03-21-session-transcript-compliance-planning-session.md
@@ -1,6 +1,7 @@
 # Session: Session Transcript Compliance — Planning
 
 **Date:** 2026-03-21
+
 **Session ID:** 29ed4bba-4c66-40af-9cc6-fd0ef675b941
 
 ## Summary


### PR DESCRIPTION
## Summary

- Added blank line between `**Date:**` and `**Session ID:**` in all 47 session transcript files so they render as separate paragraphs in Markdown
- Updated AGENTS.md to require this blank-line spacing for future transcripts

## Test plan

- [x] Open any session transcript on GitHub and verify Date and Session ID render on separate lines
- [x] Confirm AGENTS.md includes the new spacing rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)