### PR TITLE
Add createsuperuser step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ cd ragtime
 uv sync
 uv run python manage.py migrate
 
+# Create an admin user for the Django admin UI
+uv run python manage.py createsuperuser
+
 # Seed initial entity types
 uv run python manage.py load_entity_types
 


### PR DESCRIPTION
## Summary

- Add `uv run python manage.py createsuperuser` to the Installation section so new users know how to create an admin account for the Django admin UI

## Test plan

- [x] Verified README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)