### PR TITLE
Switch from SQLite to PostgreSQL with Docker Compose

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,10 @@
+# Database (PostgreSQL) — defaults match docker-compose.yml
+RAGTIME_DB_NAME=ragtime
+RAGTIME_DB_USER=ragtime
+RAGTIME_DB_PASSWORD=ragtime
+RAGTIME_DB_HOST=localhost
+RAGTIME_DB_PORT=5432
+
 # Scraping LLM provider (default: openai)
 RAGTIME_SCRAPING_PROVIDER=
 # API key for the scraping LLM provider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: ragtime
+          POSTGRES_USER: ragtime
+          POSTGRES_PASSWORD: ragtime
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ragtime"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Detach recovery agent from parent Langfuse trace context so it gets its own independent root trace
 - Increase recovery agent request limit from 15 to 30 to accommodate new tools
 
+- Switch from SQLite to PostgreSQL with Docker Compose — resolve concurrent write locking errors from parallel Django Q2 workers. Add `docker-compose.yml` with PostgreSQL 17, `manage.py dbreset` command, `RAGTIME_DB_*` configuration, CI workflow with PostgreSQL service container, and custom test runner for clean database teardown. Add timestamps to Langfuse session IDs for uniqueness across database resets — [plan](doc/plans/2026-03-23-postgresql-docker-compose.md), [feature](doc/features/2026-03-23-postgresql-docker-compose.md), [planning session](doc/sessions/2026-03-23-postgresql-docker-compose-planning-session.md), [implementation session](doc/sessions/2026-03-23-postgresql-docker-compose-implementation-session.md)
+
 ## 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ To reset the database (drops all data and recreates):
 
 ```bash
 uv run python manage.py dbreset
+uv run python manage.py createsuperuser   # Recreate the admin account
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -111,12 +111,6 @@ Optional dependency groups:
 | `observability` | `uv sync --extra observability` | [LLM observability via Langfuse](doc/README.md#llm-observability-langfuse) |
 | `recovery` | `uv sync --extra recovery` | [Agent recovery with Pydantic AI + Playwright](doc/README.md#recovery) |
 
-To run Langfuse locally alongside PostgreSQL:
-
-```bash
-docker compose --profile observability up -d
-```
-
 Set up the database, create an admin account, and start the services:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Detailed documentation lives in the [`doc/`](doc/) directory:
 
 - [Python 3.13+](https://www.python.org/downloads/)
 - [uv](https://docs.astral.sh/uv/)
+- [Docker](https://docs.docker.com/get-docker/) (for PostgreSQL)
 - [ffmpeg](https://ffmpeg.org/) (for audio downsampling)
 - [wget](https://www.gnu.org/software/wget/) (for audio downloading)
 
@@ -99,7 +100,8 @@ Detailed documentation lives in the [`doc/`](doc/) directory:
 ```bash
 git clone <repo-url>
 cd ragtime
-uv sync
+docker compose up -d              # Start PostgreSQL
+uv sync                           # Install dependencies
 ```
 
 Optional dependency groups:
@@ -108,6 +110,12 @@ Optional dependency groups:
 |-------|----------------|-------------|
 | `observability` | `uv sync --extra observability` | [LLM observability via Langfuse](doc/README.md#llm-observability-langfuse) |
 | `recovery` | `uv sync --extra recovery` | [Agent recovery with Pydantic AI + Playwright](doc/README.md#recovery) |
+
+To run Langfuse locally alongside PostgreSQL:
+
+```bash
+docker compose --profile observability up -d
+```
 
 Set up the database, create an admin account, and start the services:
 
@@ -120,6 +128,12 @@ uv run python manage.py runserver         # Start the web server
 uv run python manage.py qcluster          # Start the Django Q2 task worker (separate terminal)
 ```
 
+To reset the database (drops all data and recreates):
+
+```bash
+uv run python manage.py dbreset
+```
+
 ### Configuration
 
 You can run `uv run python manage.py configure` to launch an interactive setup wizard for all `RAGTIME_*` env vars.
@@ -130,7 +144,7 @@ Alternatively, copy [`.env.sample`](.env.sample) to `.env` and fill in your valu
 
 - **Runtime**: [Python 3.13](https://www.python.org/)
 - **Framework**: [Django 5.2](https://www.djangoproject.com/)
-- **Database**: [SQLite](https://www.sqlite.org/)
+- **Database**: [PostgreSQL 17](https://www.postgresql.org/) (via [Docker Compose](https://docs.docker.com/compose/))
 - **Vector Store**: [ChromaDB](https://www.trychroma.com/)
 - **Task Queue**: [Django Q2](https://django-q2.readthedocs.io/)
 - **AI Agents**: [Pydantic AI](https://ai.pydantic.dev/) (recovery agent)

--- a/core/management/commands/_configure_helpers.py
+++ b/core/management/commands/_configure_helpers.py
@@ -4,6 +4,24 @@ import getpass
 
 SYSTEMS = [
     {
+        "name": "Database",
+        "description": "PostgreSQL connection (defaults match docker-compose.yml)",
+        "shareable": False,
+        "subsystems": [
+            {
+                "prefix": "RAGTIME_DB",
+                "label": "Database",
+                "fields": [
+                    ("NAME", "ragtime", False),
+                    ("USER", "ragtime", False),
+                    ("PASSWORD", "ragtime", True),
+                    ("HOST", "localhost", False),
+                    ("PORT", "5432", False),
+                ],
+            },
+        ],
+    },
+    {
         "name": "LLM",
         "description": "Scraping, summarization, extraction, resolution, and translation",
         "shareable": True,

--- a/core/management/commands/dbreset.py
+++ b/core/management/commands/dbreset.py
@@ -35,21 +35,31 @@ class Command(BaseCommand):
         self.stdout.write(f"Dropping database '{db_name}'...")
 
         import psycopg
+        from psycopg import sql
 
         # Connect to the maintenance database to drop/create
-        conn_str = (
-            f"host={db_host} port={db_port} user={db_user} "
-            f"password={db_password} dbname=postgres"
-        )
-        with psycopg.connect(conn_str, autocommit=True) as conn:
+        with psycopg.connect(
+            host=db_host,
+            port=db_port,
+            user=db_user,
+            password=db_password,
+            dbname="postgres",
+            autocommit=True,
+        ) as conn:
             # Terminate existing connections
             conn.execute(
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
                 "WHERE datname = %s AND pid <> pg_backend_pid()",
                 (db_name,),
             )
-            conn.execute(f"DROP DATABASE IF EXISTS {db_name}")
-            conn.execute(f"CREATE DATABASE {db_name} OWNER {db_user}")
+            conn.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name))
+            )
+            conn.execute(
+                sql.SQL("CREATE DATABASE {} OWNER {}").format(
+                    sql.Identifier(db_name), sql.Identifier(db_user)
+                )
+            )
 
         self.stdout.write(self.style.SUCCESS(f"Database '{db_name}' recreated."))
 

--- a/core/management/commands/dbreset.py
+++ b/core/management/commands/dbreset.py
@@ -1,0 +1,66 @@
+"""Drop and recreate the PostgreSQL database."""
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Drop and recreate the PostgreSQL database, run migrations, and seed entity types"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--yes",
+            action="store_true",
+            help="Skip confirmation prompt",
+        )
+
+    def handle(self, *args, **options):
+        db = settings.DATABASES["default"]
+        db_name = db["NAME"]
+        db_user = db["USER"]
+        db_password = db["PASSWORD"]
+        db_host = db["HOST"]
+        db_port = db["PORT"]
+
+        if not options["yes"]:
+            confirm = input(
+                f"This will DROP the database '{db_name}' and all its data. "
+                f"Are you sure? [y/N]: "
+            )
+            if confirm.strip().lower() not in ("y", "yes"):
+                self.stdout.write("Cancelled.")
+                return
+
+        self.stdout.write(f"Dropping database '{db_name}'...")
+
+        import psycopg
+
+        # Connect to the maintenance database to drop/create
+        conn_str = (
+            f"host={db_host} port={db_port} user={db_user} "
+            f"password={db_password} dbname=postgres"
+        )
+        with psycopg.connect(conn_str, autocommit=True) as conn:
+            # Terminate existing connections
+            conn.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (db_name,),
+            )
+            conn.execute(f"DROP DATABASE IF EXISTS {db_name}")
+            conn.execute(f"CREATE DATABASE {db_name} OWNER {db_user}")
+
+        self.stdout.write(self.style.SUCCESS(f"Database '{db_name}' recreated."))
+
+        self.stdout.write("Running migrations...")
+        call_command("migrate", verbosity=0)
+        self.stdout.write(self.style.SUCCESS("Migrations applied."))
+
+        self.stdout.write("Seeding entity types...")
+        call_command("load_entity_types", verbosity=0)
+        self.stdout.write(self.style.SUCCESS("Entity types loaded."))
+
+        self.stdout.write(
+            "\nDone. Run 'uv run python manage.py createsuperuser' to create an admin account."
+        )

--- a/core/tests/test_configure.py
+++ b/core/tests/test_configure.py
@@ -226,6 +226,7 @@ class ConfigureWizardTest(TestCase):
     def test_shared_mode_wizard(self, mock_input, mock_getpass):
         """Test wizard with shared LLM provider/key."""
         mock_getpass.side_effect = [
+            "",               # DB password (keep default)
             "sk-newkey123",   # Shared LLM API key
             "sk-newkey123",   # Transcription API key
             "",               # Recovery agent API key (keep default)
@@ -233,6 +234,10 @@ class ConfigureWizardTest(TestCase):
             "",               # Langfuse public key (keep default)
         ]
         mock_input.side_effect = [
+            "",               # DB name (keep default)
+            "",               # DB user (keep default)
+            "",               # DB host (keep default)
+            "",               # DB port (keep default)
             "Y",              # Share provider/key? Yes
             "openai",         # Provider
             "gpt-4.1-mini",  # Scraping model
@@ -326,6 +331,7 @@ class ConfigureWizardTest(TestCase):
     def test_rerun_preserves_non_ragtime_lines(self, mock_input, mock_getpass):
         """Test that re-running preserves non-RAGTIME lines."""
         mock_getpass.side_effect = [
+            "",               # DB password (keep default)
             "sk-newkey123",   # Shared LLM API key
             "sk-newkey123",   # Transcription API key
             "",               # Recovery agent API key (keep default)
@@ -333,6 +339,10 @@ class ConfigureWizardTest(TestCase):
             "",               # Langfuse public key (keep default)
         ]
         mock_input.side_effect = [
+            "",               # DB name (keep default)
+            "",               # DB user (keep default)
+            "",               # DB host (keep default)
+            "",               # DB port (keep default)
             "Y",              # Share provider/key? Yes
             "openai",         # Provider
             "gpt-4.1-mini",  # Scraping model

--- a/doc/README.md
+++ b/doc/README.md
@@ -194,9 +194,10 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
    uv sync --extra observability
    ```
 
-2. Run Langfuse locally via Docker Compose.
-
-   See [this walk through guide](https://langfuse.com/self-hosting/deployment/docker-compose).
+2. Start Langfuse via Docker Compose:
+   ```bash
+   docker compose --profile observability up -d
+   ```
 
 3. Configure via the wizard or `.env`:
    ```
@@ -213,6 +214,42 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
 4. Process an episode and view traces at `http://localhost:3000`.
 
 When disabled (the default), Langfuse is never imported and there is zero overhead.
+
+## Development
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) — required for PostgreSQL (and optionally Langfuse)
+- [Python 3.13+](https://www.python.org/downloads/) and [uv](https://docs.astral.sh/uv/)
+
+### Starting services
+
+```bash
+docker compose up -d                              # PostgreSQL only
+docker compose --profile observability up -d      # PostgreSQL + Langfuse
+```
+
+### Running tests
+
+PostgreSQL must be running before running tests:
+
+```bash
+docker compose up -d
+uv run python manage.py test
+```
+
+Django's test runner creates a temporary `test_ragtime` database automatically and destroys it after the run. In CI, the GitHub Actions workflow starts a PostgreSQL service container with the same credentials.
+
+### Resetting the database
+
+To drop all data and start fresh:
+
+```bash
+uv run python manage.py dbreset        # interactive confirmation
+uv run python manage.py dbreset --yes  # skip confirmation
+```
+
+This drops and recreates the `ragtime` database, runs all migrations, and seeds entity types. Run `createsuperuser` afterwards to recreate the admin account.
 
 ## Feature Documentation
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -229,6 +229,14 @@ docker compose up -d                              # PostgreSQL only
 docker compose --profile observability up -d      # PostgreSQL + Langfuse
 ```
 
+| Service | URL | Profile |
+|---------|-----|---------|
+| PostgreSQL | `localhost:5432` | always |
+| Langfuse | `http://localhost:3000` | `observability` |
+| Langfuse DB | `localhost:5433` | `observability` |
+
+All ports are bound to `127.0.0.1` (localhost only, not exposed to the network).
+
 ### Running tests
 
 PostgreSQL must be running before running tests:

--- a/doc/README.md
+++ b/doc/README.md
@@ -198,9 +198,13 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
 
    See [this walk through guide](https://langfuse.com/self-hosting/deployment/docker-compose).
 
-   **Port conflict:** Langfuse's docker-compose.yml exposes its PostgreSQL on port 5432, which conflicts with RAGtime's. Run this in the Langfuse directory to move it to port 5433:
+   **Port conflict:** Langfuse's docker-compose.yml exposes its PostgreSQL on port 5432, which conflicts with RAGtime's. Run one of these in the Langfuse directory to move it to port 5433:
    ```bash
+   # macOS (BSD sed)
    sed -i '' 's/127.0.0.1:5432:5432/127.0.0.1:5433:5432/' docker-compose.yml
+
+   # Linux (GNU sed)
+   sed -i 's/127.0.0.1:5432:5432/127.0.0.1:5433:5432/' docker-compose.yml
    ```
    This only changes the host-side port — Langfuse's internal connections use the Docker network and are unaffected.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -198,7 +198,13 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
 
    See [this walk through guide](https://langfuse.com/self-hosting/deployment/docker-compose).
 
-   **Port conflict:** Langfuse's docker-compose.yml exposes its own PostgreSQL on port 5432, which conflicts with RAGtime's PostgreSQL. Change the Langfuse PostgreSQL port mapping to a different port (e.g. `5433:5432`) in their compose file.
+   **Port conflict:** Langfuse's docker-compose.yml exposes its own PostgreSQL on port 5432, which conflicts with RAGtime's PostgreSQL. To avoid this, create a `docker-compose.override.yml` in the Langfuse directory:
+   ```yaml
+   services:
+     db:
+       ports:
+         - "127.0.0.1:5433:5432"
+   ```
 
 3. Configure via the wizard or `.env`:
    ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -233,7 +233,7 @@ When disabled (the default), Langfuse is never imported and there is zero overhe
 docker compose up -d    # Start PostgreSQL on localhost:5432
 ```
 
-The port is bound to `127.0.0.1` (localhost only, not exposed to the network).
+The `ragtime` database is created automatically on first start. The port is bound to `127.0.0.1` (localhost only, not exposed to the network).
 
 ### Running tests
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -194,10 +194,9 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
    uv sync --extra observability
    ```
 
-2. Start Langfuse via Docker Compose:
-   ```bash
-   docker compose --profile observability up -d
-   ```
+2. Run Langfuse locally via Docker Compose.
+
+   See [this walk through guide](https://langfuse.com/self-hosting/deployment/docker-compose).
 
 3. Configure via the wizard or `.env`:
    ```
@@ -219,23 +218,16 @@ When disabled (the default), Langfuse is never imported and there is zero overhe
 
 ### Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) — required for PostgreSQL (and optionally Langfuse)
+- [Docker](https://docs.docker.com/get-docker/) — required for PostgreSQL
 - [Python 3.13+](https://www.python.org/downloads/) and [uv](https://docs.astral.sh/uv/)
 
 ### Starting services
 
 ```bash
-docker compose up -d                              # PostgreSQL only
-docker compose --profile observability up -d      # PostgreSQL + Langfuse
+docker compose up -d    # Start PostgreSQL on localhost:5432
 ```
 
-| Service | URL | Profile |
-|---------|-----|---------|
-| PostgreSQL | `localhost:5432` | always |
-| Langfuse | `http://localhost:3000` | `observability` |
-| Langfuse DB | `localhost:5433` | `observability` |
-
-All ports are bound to `127.0.0.1` (localhost only, not exposed to the network).
+The port is bound to `127.0.0.1` (localhost only, not exposed to the network).
 
 ### Running tests
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -198,13 +198,11 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
 
    See [this walk through guide](https://langfuse.com/self-hosting/deployment/docker-compose).
 
-   **Port conflict:** Langfuse's docker-compose.yml exposes its own PostgreSQL on port 5432, which conflicts with RAGtime's PostgreSQL. To avoid this, create a `docker-compose.override.yml` in the Langfuse directory:
-   ```yaml
-   services:
-     db:
-       ports:
-         - "127.0.0.1:5433:5432"
+   **Port conflict:** Langfuse's docker-compose.yml exposes its PostgreSQL on port 5432, which conflicts with RAGtime's. Run this in the Langfuse directory to move it to port 5433:
+   ```bash
+   sed -i '' 's/127.0.0.1:5432:5432/127.0.0.1:5433:5432/' docker-compose.yml
    ```
+   This only changes the host-side port — Langfuse's internal connections use the Docker network and are unaffected.
 
 3. Configure via the wizard or `.env`:
    ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -198,6 +198,8 @@ RAGtime optionally integrates with [Langfuse](https://langfuse.com) to trace all
 
    See [this walk through guide](https://langfuse.com/self-hosting/deployment/docker-compose).
 
+   **Port conflict:** Langfuse's docker-compose.yml exposes its own PostgreSQL on port 5432, which conflicts with RAGtime's PostgreSQL. Change the Langfuse PostgreSQL port mapping to a different port (e.g. `5433:5432`) in their compose file.
+
 3. Configure via the wizard or `.env`:
    ```
    uv run python manage.py configure

--- a/doc/features/2026-03-23-postgresql-docker-compose.md
+++ b/doc/features/2026-03-23-postgresql-docker-compose.md
@@ -1,0 +1,81 @@
+# Switch from SQLite to PostgreSQL with Docker Compose
+
+**Date:** 2026-03-23
+
+## Problem
+
+Django Q2 workers processing pipeline steps in parallel caused `sqlite3.OperationalError: database is locked` errors. SQLite only allows one writer at a time, and the 30-second timeout was insufficient under concurrent workloads.
+
+## Changes
+
+### Docker Compose
+
+Added `docker-compose.yml` with PostgreSQL 17 Alpine. Port bound to `127.0.0.1:5432` (localhost only, not exposed to the network). The `ragtime` database, user, and password are created automatically on first container start.
+
+### Database backend
+
+Switched `DATABASES` in `settings.py` from `sqlite3` to `postgresql`. Configured via `RAGTIME_DB_*` env vars with defaults matching the Docker Compose config for zero-config setup. Added `psycopg[binary]` to core dependencies.
+
+### Database reset command
+
+Added `manage.py dbreset` — drops and recreates the PostgreSQL database, runs migrations, seeds entity types. Supports `--yes` flag to skip confirmation. Connects to the `postgres` maintenance database to perform the DROP/CREATE.
+
+### CI workflow
+
+Added PostgreSQL 17 service container to the GitHub Actions CI workflow with the same credentials as `docker-compose.yml`.
+
+### Test runner
+
+Added `PostgresTestRunner` that patches `DatabaseCreation._destroy_test_db` to terminate lingering connections before `DROP DATABASE`. Some tests spawn async threads (via `asyncio.run` for the recovery agent) that create DB connections outliving the test.
+
+### Langfuse session ID uniqueness
+
+Added `YYYY-MM-DD-HH-MM` timestamps to `processing-run-*` and `recovery-run-*` Langfuse session IDs so they remain unique across database resets (auto-increment PKs restart from 1).
+
+### Configuration wizard
+
+Added Database system to the configure wizard with 5 fields: name, user, password (secret), host, port.
+
+### Documentation
+
+- Added Development section to `doc/README.md` with prerequisites, service startup, test running, and database reset instructions
+- Added port conflict note for Langfuse users (their docker-compose.yml also uses port 5432)
+- Updated README Getting Started with Docker prerequisite
+- Updated Tech Stack to reference PostgreSQL
+
+## Key Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| PostgreSQL version | 17 Alpine | Latest stable, small image |
+| Port binding | `127.0.0.1:5432` | Localhost only for security |
+| Default credentials | `ragtime/ragtime/ragtime` | Dev defaults, match Docker Compose |
+
+## Verification
+
+1. `docker compose up -d` — PostgreSQL starts and is healthy
+2. `uv run python manage.py migrate` — migrations apply against PostgreSQL
+3. `uv run python manage.py test` — all 243 tests pass, test DB tears down cleanly
+4. `uv run python manage.py dbreset --yes` — drops/recreates DB successfully
+5. Process 2+ episodes concurrently — no `database is locked` errors
+6. Langfuse session IDs are unique across database resets
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `docker-compose.yml` | New — PostgreSQL service |
+| `pyproject.toml` | Added `psycopg[binary]>=3.2,<4` |
+| `ragtime/settings.py` | PostgreSQL backend, `RAGTIME_DB_*` vars, `TEST_RUNNER` |
+| `ragtime/test_runner.py` | New — PostgresTestRunner |
+| `.env.sample` | Added `RAGTIME_DB_*` section |
+| `.github/workflows/ci.yml` | Added PostgreSQL service container |
+| `core/management/commands/_configure_helpers.py` | Added Database system |
+| `core/management/commands/dbreset.py` | New — database reset command |
+| `core/tests/test_configure.py` | Updated wizard tests for DB fields |
+| `episodes/tests/test_summarize.py` | Fixed varchar test for PostgreSQL |
+| `episodes/observability.py` | Timestamp in processing-run session ID |
+| `episodes/agents/agent.py` | Timestamp in recovery-run session ID |
+| `README.md` | Docker prerequisite, dbreset command |
+| `CLAUDE.md` | Updated tech choice from SQLite to PostgreSQL |
+| `doc/README.md` | Development section, Langfuse port conflict note |

--- a/doc/plans/2026-03-23-postgresql-docker-compose.md
+++ b/doc/plans/2026-03-23-postgresql-docker-compose.md
@@ -1,0 +1,26 @@
+# Switch from SQLite to PostgreSQL with Docker Compose
+
+**Date:** 2026-03-23
+
+## Context
+
+Django Q2 workers run pipeline steps in parallel, causing `sqlite3.OperationalError: database is locked` errors. SQLite only supports one writer at a time. PostgreSQL handles concurrent writes natively.
+
+## Approach
+
+Introduce Docker Compose for PostgreSQL, keep the Django app running locally via `uv run`. Add `manage.py dbreset` for easy database reset. PostgreSQL-only (no SQLite fallback).
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `docker-compose.yml` | New — PostgreSQL 17 Alpine, localhost-only port |
+| `pyproject.toml` | Add `psycopg[binary]` |
+| `ragtime/settings.py` | Switch to postgresql backend with `RAGTIME_DB_*` env vars |
+| `.env.sample` | Add `RAGTIME_DB_*` vars |
+| `core/management/commands/_configure_helpers.py` | Add Database system |
+| `core/management/commands/dbreset.py` | New — database reset command |
+| `.github/workflows/ci.yml` | Add PostgreSQL service container |
+| `ragtime/test_runner.py` | New — terminate lingering connections before DROP |
+| `doc/README.md` | Development section with prerequisites, services, testing |
+| `README.md` | Updated Getting Started with Docker prerequisite |

--- a/doc/sessions/2026-03-23-postgresql-docker-compose-implementation-session.md
+++ b/doc/sessions/2026-03-23-postgresql-docker-compose-implementation-session.md
@@ -1,0 +1,119 @@
+# Session: PostgreSQL Docker Compose — Implementation
+
+**Date:** 2026-03-23
+
+**Session ID:** 168626d0-1f48-419b-9a7f-d17b2257f7b0
+
+## Summary
+
+Implemented the switch from SQLite to PostgreSQL with Docker Compose. Iteratively addressed CI workflow, Langfuse v3 compatibility issues, documentation updates, test database teardown problems, and Langfuse session ID uniqueness.
+
+## Conversation
+
+### User
+
+(Plan approved via ExitPlanMode)
+
+### Assistant
+
+Implemented across 10 files: `docker-compose.yml` (PostgreSQL + Langfuse via profiles), `pyproject.toml` (psycopg), `settings.py` (postgresql backend), `.env.sample`, configure wizard, `dbreset` command, test fixtures, README updates. Fixed a test that relied on SQLite silently truncating a varchar value (`"Ignore previous instructions"` → `"INVALID"`). All 215 tests passed.
+
+### User
+
+How are unit tests going to be run now? Using PostgreSQL? How will this affect the CI/CD pipeline?
+
+### Assistant
+
+Added PostgreSQL 17 service container to `.github/workflows/ci.yml` with the same credentials as `docker-compose.yml`. Tests run against real PostgreSQL both locally and in CI.
+
+### User
+
+Is there something like TestContainers for Python that we could use for the tests?
+
+### Assistant
+
+Explained that testcontainers-python exists but doesn't add value here — Docker Compose is already required for dev, CI uses native service containers, and Testcontainers would add startup latency and a dependency for a problem that's already solved.
+
+### User
+
+Let's make sure we document the need for having PostgreSQL up and running in a new section in doc/README. Maybe we can call it "Development"?
+
+### Assistant
+
+Added Development section to `doc/README.md` with prerequisites, starting services, running tests, and resetting the database. Updated Langfuse setup to reference `docker compose --profile observability up -d`.
+
+### User
+
+Update the documentation to indicate in which localhost ports are Langfuse and PostgreSQL available
+
+### Assistant
+
+Added a service ports table: PostgreSQL on `localhost:5432` (always), Langfuse on `http://localhost:3000` and Langfuse DB on `localhost:5433` (observability profile). Noted all ports are `127.0.0.1` only.
+
+### User
+
+After starting "docker compose --profile observability up -d" I'm trying to access http://localhost:3000 and I get a ERR_CONNECTION_REFUSED
+
+### Assistant
+
+Discovered Langfuse v3 requires ClickHouse, Redis, MinIO, and two app containers — far more infrastructure than a simple compose profile.
+
+### User
+
+Ummm... on second thought let's leave Langfuse out of the Docker compose as it was before.
+
+### Assistant
+
+Removed all Langfuse services from docker-compose.yml, keeping PostgreSQL only. Reverted Langfuse setup docs to reference their self-hosting guide.
+
+### User
+
+It seems that the Langfuse docker compose configuration is also exposing the PostgreSQL port at 5432 and this clashes with our PostgreSQL instance.
+
+### Assistant
+
+Added a port conflict note to the Langfuse setup section with a `docker-compose.override.yml` workaround.
+
+### User
+
+Can one change the PostgreSQL port for Langfuse via the command-line?
+
+### Assistant
+
+Reviewed Langfuse's docker-compose.yml from GitHub. Port is hardcoded at line 162. Replaced the override.yml approach with a simpler sed command: `sed -i '' 's/127.0.0.1:5432:5432/127.0.0.1:5433:5432/' docker-compose.yml`. Internal Docker network connections are unaffected since `DATABASE_URL` uses the container hostname.
+
+### User
+
+Regarding "To reset the database (drops all data and recreates):" in the README, do we need to re-create the superadmin user afterwards?
+
+### Assistant
+
+Yes — added `createsuperuser` after `dbreset` in the README. The command already prints a reminder at the end.
+
+### User
+
+Do I need to explicitly create the ragtime database in PostgreSQL or will it be automatically created?
+
+### Assistant
+
+No — Docker's `POSTGRES_DB: ragtime` env var creates it automatically on first container start. Added a note to doc/README.
+
+### User
+
+With the SQLite implementation we had added delays in the code to prevent concurrent write access. Have we removed that code?
+
+### Assistant
+
+Searched the codebase — found no SQLite-specific delays or workarounds. The only SQLite config was the `timeout: 30` in DATABASES which was already removed.
+
+### User
+
+In Langfuse, for a given session id like "processing-run-1-episode-1" I am seeing old traces associated with it from days ago. Could it be that since I am resetting the database, the session id is the same but for different runs and this is the cause for this issue?
+
+### Assistant
+
+Confirmed: auto-increment PKs restart from 1 after database reset, producing duplicate session IDs. Discussed options: (1) add timestamp, (2) use UUIDs for PKs, (3) dbreset counter. User chose option 1 with `YYYY-MM-DD-HH-MM` format.
+
+Added timestamps to both `processing-run-*` and `recovery-run-*` session IDs. Also fixed test database teardown — async threads from recovery agent tests left DB connections open, preventing PostgreSQL from dropping the test database. Created `PostgresTestRunner` that patches `_destroy_test_db` to terminate lingering connections before DROP.
+
+All 243 tests pass with clean teardown.

--- a/doc/sessions/2026-03-23-postgresql-docker-compose-planning-session.md
+++ b/doc/sessions/2026-03-23-postgresql-docker-compose-planning-session.md
@@ -1,0 +1,51 @@
+# Session: PostgreSQL Docker Compose — Planning
+
+**Date:** 2026-03-23
+
+**Session ID:** 168626d0-1f48-419b-9a7f-d17b2257f7b0
+
+## Summary
+
+Planned the switch from SQLite to PostgreSQL with Docker Compose to fix concurrent write locking errors. Discussed options for local PostgreSQL (Docker Compose), database reset tooling, Langfuse integration, and SQLite fallback.
+
+## Conversation
+
+### User
+
+I'm seeing this error "sqlite3.OperationalError: database is locked" in the logs. What is the root cause?
+
+### Assistant
+
+Explained the root cause: SQLite concurrent write contention from multiple Django Q2 workers. Two pipeline steps running in parallel both trying to write, and SQLite only allows one writer at a time. Proposed three fixes: increase timeout, enable WAL mode, or limit to 1 worker.
+
+### User
+
+What about switching to use PostgreSQL? What would this entail?
+
+### Assistant
+
+Outlined the migration: change `DATABASES` backend, add `psycopg[binary]`, update `.env.sample` and configure wizard, no model/migration changes needed (Django ORM abstracts the DB layer). Discussed trade-offs: gains concurrent writes and better performance, loses zero-config simplicity. Recommended PostgreSQL for a multi-worker Django app.
+
+### User
+
+Which options do we have to spin up a local PostgreSQL server? Docker? We already have to spin up the actual Django app and the Django Q2 processes. Can we use something like Docker Compose for this? If we introduce PostgreSQL, how can we make it easier for users to create the database or reset the data if they want?
+
+### Assistant
+
+Explored the codebase to understand the current setup. Designed a plan with: Docker Compose for PostgreSQL (and optionally Langfuse via profiles), `manage.py dbreset` command, `RAGTIME_DB_*` env vars with dev defaults matching Docker Compose, Database section in configure wizard.
+
+### User
+
+But Langfuse is optional, how can we optionally spin up a Langfuse instance with Docker compose?
+
+### Assistant
+
+Explained Docker Compose profiles: tag Langfuse services with `profiles: ["observability"]`, they only start with `docker compose --profile observability up -d`. Regular `docker compose up -d` starts only PostgreSQL.
+
+### User
+
+Selected PostgreSQL only (no SQLite fallback) and asked about port security.
+
+### Assistant
+
+Ports bound to `127.0.0.1` only, not exposed to network. Renamed `resetdb` to `dbreset` per user preference. Plan approved.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,37 +15,5 @@ services:
       timeout: 5s
       retries: 5
 
-  langfuse-db:
-    image: postgres:17-alpine
-    profiles: ["observability"]
-    ports:
-      - "127.0.0.1:5433:5432"
-    environment:
-      POSTGRES_DB: langfuse
-      POSTGRES_USER: langfuse
-      POSTGRES_PASSWORD: langfuse
-    volumes:
-      - langfuse-pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD", "pg_isready", "-U", "langfuse"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  langfuse:
-    image: langfuse/langfuse:latest
-    profiles: ["observability"]
-    ports:
-      - "127.0.0.1:3000:3000"
-    environment:
-      DATABASE_URL: postgresql://langfuse:langfuse@langfuse-db:5432/langfuse
-      NEXTAUTH_URL: http://localhost:3000
-      NEXTAUTH_SECRET: ragtime-langfuse-dev-secret
-      SALT: ragtime-langfuse-dev-salt
-    depends_on:
-      langfuse-db:
-        condition: service_healthy
-
 volumes:
   pgdata:
-  langfuse-pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  db:
+    image: postgres:17-alpine
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_DB: ragtime
+      POSTGRES_USER: ragtime
+      POSTGRES_PASSWORD: ragtime
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "ragtime"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  langfuse-db:
+    image: postgres:17-alpine
+    profiles: ["observability"]
+    ports:
+      - "127.0.0.1:5433:5432"
+    environment:
+      POSTGRES_DB: langfuse
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse
+    volumes:
+      - langfuse-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "langfuse"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  langfuse:
+    image: langfuse/langfuse:latest
+    profiles: ["observability"]
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse@langfuse-db:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ragtime-langfuse-dev-secret
+      SALT: ragtime-langfuse-dev-salt
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+  langfuse-pgdata:

--- a/episodes/agents/agent.py
+++ b/episodes/agents/agent.py
@@ -223,9 +223,10 @@ async def _run_with_langfuse(agent, system_prompt, deps, event):
             token = attach(OTelContext())
 
             try:
+                ts = event.timestamp.strftime("%Y-%m-%d-%H-%M")
                 session_id = (
                     f"recovery-run-{event.processing_run_id}-episode-{event.episode_id}"
-                    f"-attempt-{event.attempt_number}"
+                    f"-attempt-{event.attempt_number}-{ts}"
                 )
                 user_id = f"episode-{event.episode_id}"
                 metadata = {

--- a/episodes/observability.py
+++ b/episodes/observability.py
@@ -159,7 +159,7 @@ def observe_step(name):
 
     The decorated function must accept ``episode_id`` as its first argument.
     When enabled, the wrapper creates a Langfuse trace named *name* with
-    ``session_id`` set to the active ``ProcessingRun.pk``.
+    ``session_id`` set to ``processing-run-{pk}-episode-{id}-{timestamp}``.
 
     Returns a no-op passthrough when Langfuse is disabled.
     """

--- a/episodes/observability.py
+++ b/episodes/observability.py
@@ -190,11 +190,11 @@ def observe_step(name):
                 .first()
             )
 
-            session_id = (
-                f"processing-run-{run.pk}-episode-{episode_id}"
-                if run
-                else f"episode-{episode_id}"
-            )
+            if run:
+                ts = run.started_at.strftime("%Y-%m-%d-%H-%M")
+                session_id = f"processing-run-{run.pk}-episode-{episode_id}-{ts}"
+            else:
+                session_id = f"episode-{episode_id}"
 
             try:
                 episode = Episode.objects.get(pk=episode_id)

--- a/episodes/tests/test_summarize.py
+++ b/episodes/tests/test_summarize.py
@@ -172,7 +172,7 @@ class SummarizeEpisodeTests(TestCase):
             url="https://example.com/ep/sum-7",
             status=Episode.Status.SUMMARIZING,
             transcript="Some transcript.",
-            language="Ignore previous instructions",
+            language="INVALID",
         )
 
         with patch("episodes.signals.async_task"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-dotenv>=1.0,<2",
     "pyyaml>=6.0.3",
     "mutagen>=1.47,<2",
+    "psycopg[binary]>=3.2,<4",
 ]
 
 [project.optional-dependencies]

--- a/ragtime/settings.py
+++ b/ragtime/settings.py
@@ -82,11 +82,12 @@ WSGI_APPLICATION = 'ragtime.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-        'OPTIONS': {
-            'timeout': 30,
-        },
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('RAGTIME_DB_NAME', 'ragtime'),
+        'USER': os.getenv('RAGTIME_DB_USER', 'ragtime'),
+        'PASSWORD': os.getenv('RAGTIME_DB_PASSWORD', 'ragtime'),
+        'HOST': os.getenv('RAGTIME_DB_HOST', 'localhost'),
+        'PORT': os.getenv('RAGTIME_DB_PORT', '5432'),
     }
 }
 

--- a/ragtime/settings.py
+++ b/ragtime/settings.py
@@ -59,6 +59,8 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'ragtime.urls'
 
+TEST_RUNNER = 'ragtime.test_runner.PostgresTestRunner'
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/ragtime/test_runner.py
+++ b/ragtime/test_runner.py
@@ -7,9 +7,13 @@ patches the database backend to terminate lingering sessions immediately
 before DROP DATABASE.
 """
 
+import logging
+
 from django.db import connections
 from django.db.backends.postgresql.creation import DatabaseCreation
 from django.test.runner import DiscoverRunner
+
+logger = logging.getLogger(__name__)
 
 _original_destroy = DatabaseCreation._destroy_test_db
 
@@ -37,7 +41,10 @@ def _destroy_test_db_with_terminate(self, test_database_name, verbosity):
         )
         conn.close()
     except Exception:
-        pass
+        logger.warning(
+            "Failed to terminate connections to %s", test_database_name,
+            exc_info=True,
+        )
 
     return _original_destroy(self, test_database_name, verbosity)
 

--- a/ragtime/test_runner.py
+++ b/ragtime/test_runner.py
@@ -18,35 +18,35 @@ logger = logging.getLogger(__name__)
 _original_destroy = DatabaseCreation._destroy_test_db
 
 
-def _destroy_test_db_with_terminate(self, test_database_name, verbosity):
+def _destroy_test_db_with_terminate(self, *args, **kwargs):
     """Terminate active connections then drop the test database."""
+    test_database_name = args[0] if args else kwargs.get("test_database_name", "")
     connections.close_all()
 
     settings_dict = self.connection.settings_dict
     try:
         import psycopg
 
-        conn = psycopg.connect(
+        with psycopg.connect(
             host=settings_dict["HOST"],
             port=settings_dict["PORT"],
             user=settings_dict["USER"],
             password=settings_dict["PASSWORD"],
             dbname="postgres",
             autocommit=True,
-        )
-        conn.execute(
-            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-            "WHERE datname = %s AND pid <> pg_backend_pid()",
-            (test_database_name,),
-        )
-        conn.close()
+        ) as conn:
+            conn.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (test_database_name,),
+            )
     except Exception:
         logger.warning(
             "Failed to terminate connections to %s", test_database_name,
             exc_info=True,
         )
 
-    return _original_destroy(self, test_database_name, verbosity)
+    return _original_destroy(self, *args, **kwargs)
 
 
 class PostgresTestRunner(DiscoverRunner):

--- a/ragtime/test_runner.py
+++ b/ragtime/test_runner.py
@@ -1,0 +1,52 @@
+"""Custom test runner that handles PostgreSQL lingering connections.
+
+Some tests spawn async threads (e.g. asyncio.run for the recovery agent)
+that create database connections which outlive the test. PostgreSQL
+refuses to drop a database with active connections. This runner
+patches the database backend to terminate lingering sessions immediately
+before DROP DATABASE.
+"""
+
+from django.db import connections
+from django.db.backends.postgresql.creation import DatabaseCreation
+from django.test.runner import DiscoverRunner
+
+_original_destroy = DatabaseCreation._destroy_test_db
+
+
+def _destroy_test_db_with_terminate(self, test_database_name, verbosity):
+    """Terminate active connections then drop the test database."""
+    connections.close_all()
+
+    settings_dict = self.connection.settings_dict
+    try:
+        import psycopg
+
+        conn = psycopg.connect(
+            host=settings_dict["HOST"],
+            port=settings_dict["PORT"],
+            user=settings_dict["USER"],
+            password=settings_dict["PASSWORD"],
+            dbname="postgres",
+            autocommit=True,
+        )
+        conn.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = %s AND pid <> pg_backend_pid()",
+            (test_database_name,),
+        )
+        conn.close()
+    except Exception:
+        pass
+
+    return _original_destroy(self, test_database_name, verbosity)
+
+
+class PostgresTestRunner(DiscoverRunner):
+    def setup_test_environment(self, **kwargs):
+        super().setup_test_environment(**kwargs)
+        DatabaseCreation._destroy_test_db = _destroy_test_db_with_terminate
+
+    def teardown_test_environment(self, **kwargs):
+        DatabaseCreation._destroy_test_db = _original_destroy
+        super().teardown_test_environment(**kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -1463,6 +1463,41 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1821,6 +1856,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mutagen" },
     { name = "openai" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
@@ -1844,6 +1880,7 @@ requires-dist = [
     { name = "mutagen", specifier = ">=1.47,<2" },
     { name = "openai", specifier = ">=1.0,<2" },
     { name = "playwright", marker = "extra == 'recovery'", specifier = ">=1.40,<2" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "pydantic-ai", marker = "extra == 'recovery'", specifier = ">=1.30,<2" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0.3" },


### PR DESCRIPTION
## Summary

- **Docker Compose** — add `docker-compose.yml` with PostgreSQL 17 Alpine (localhost-only port binding for security)
- **Database backend** — switch from SQLite to PostgreSQL with `RAGTIME_DB_*` env vars (defaults match Docker Compose for zero-config)
- **`manage.py dbreset`** — new command to drop/recreate the database, run migrations, and seed entity types
- **CI workflow** — add PostgreSQL service container to GitHub Actions
- **Test runner** — custom `PostgresTestRunner` terminates lingering async connections before test DB teardown
- **Langfuse session IDs** — add timestamps (`YYYY-MM-DD-HH-MM`) to session IDs for uniqueness across database resets
- **Documentation** — Development section in `doc/README.md`, Langfuse port conflict workaround, updated Getting Started

## Test plan

- [x] `docker compose up -d` — PostgreSQL starts and is healthy
- [x] `uv run python manage.py migrate` — all migrations apply
- [x] `uv run python manage.py test` — all 243 tests pass with clean teardown
- [x] `uv run python manage.py dbreset --yes` — drops/recreates DB
- [ ] Process 2+ episodes concurrently — no `database is locked` errors
- [x] CI workflow passes with PostgreSQL service container

🤖 Generated with [Claude Code](https://claude.com/claude-code)