### PR TITLE
Log Pydantic AI tool definitions to Langfuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Log Pydantic AI tool definitions to Langfuse — the recovery agent's OTel instrumentation captures conversation flow but not the `tools` JSON schemas sent to the model. Add `_get_tool_definitions()` and `_log_tool_definitions()` helpers that extract tool schemas from the agent and log them as a `recovery-tool-definitions` Langfuse event inside the recovery trace — [plan](doc/plans/2026-03-23-add-tools-langfuse.md), [feature](doc/features/2026-03-23-add-tools-langfuse.md), [planning session](doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md), [implementation session](doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md)
+
 - Recovery agent language awareness — pass episode language to the recovery agent, add `translate_text` tool (backed by dedicated `RAGTIME_TRANSLATION_*` provider) so the agent translates UI labels before clicking on non-English pages. Add visual analysis fallback: `analyze_screenshot` returns screenshots for LLM visual interpretation, `click_at_coordinates` clicks visually identified elements, `intercept_audio_requests` captures streaming audio URLs via network interception — [plan](doc/plans/2026-03-23-recovery-agent-language-awareness.md), [feature](doc/features/2026-03-23-recovery-agent-language-awareness.md), [planning session](doc/sessions/2026-03-23-recovery-agent-language-awareness-planning-session.md), [implementation session](doc/sessions/2026-03-23-recovery-agent-language-awareness-implementation-session.md)
 
 ### Changed

--- a/doc/features/2026-03-23-add-tools-langfuse.md
+++ b/doc/features/2026-03-23-add-tools-langfuse.md
@@ -1,0 +1,34 @@
+# Log Pydantic AI tool definitions to Langfuse
+
+**Date:** 2026-03-23
+
+## Problem
+
+Pydantic AI's OTel instrumentation (`instrument=True`) captures conversation flow and individual tool calls, but does not include the `tools` array — the JSON schemas sent to the model describing available tools. This makes it difficult to audit what tools the model had access to during a recovery run.
+
+## Changes
+
+- **`episodes/agents/agent.py`** — Added two helpers:
+  - `_get_tool_definitions(agent)`: Extracts tool name, description, and `parameters` JSON schema from `agent._function_toolset.tools`. Returns `[]` on any error.
+  - `_log_tool_definitions(agent, episode_id)`: Creates a `recovery-tool-definitions` Langfuse event with `input={"tools": [...]}` and metadata (`episode_id`, `tool_count`). Silently swallows errors.
+  - Modified `_run_with_langfuse()` to call `_log_tool_definitions()` inside the `propagate_attributes` context, before `agent.run()`.
+
+- **`episodes/tests/test_agent_langfuse.py`** — New test file with 6 tests covering schema extraction (single tool, multiple tools, error handling) and Langfuse event creation (happy path, no tools, Langfuse errors).
+
+## Key parameters
+
+None — no new configuration. The feature activates automatically when `RAGTIME_LANGFUSE_ENABLED=True`.
+
+## Verification
+
+1. Trigger a recovery agent run (e.g. via a scraping failure on a protected episode).
+2. Open the recovery trace in Langfuse.
+3. Look for the `recovery-tool-definitions` event — it should contain the full JSON schema for all 11 tools.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `episodes/agents/agent.py` | Add `_get_tool_definitions()`, `_log_tool_definitions()`, call from `_run_with_langfuse()` |
+| `episodes/tests/test_agent_langfuse.py` | New: 6 unit tests for tool definition extraction and Langfuse logging |
+| `CHANGELOG.md` | Add entry under 2026-03-23 |

--- a/doc/plans/2026-03-23-add-tools-langfuse.md
+++ b/doc/plans/2026-03-23-add-tools-langfuse.md
@@ -1,0 +1,19 @@
+# Log Pydantic AI tool definitions to Langfuse
+
+**Date:** 2026-03-23
+
+## Problem
+
+When viewing recovery agent traces in Langfuse, the `tools` array (JSON schemas describing each tool available to the model) is not visible in the input. Pydantic AI's built-in OTel instrumentation captures conversation flow and tool call invocations but does not include the tool definitions sent to the model.
+
+## Approach
+
+Log tool definitions manually as a Langfuse event inside the existing `_run_with_langfuse()` function. This is the least intrusive option compared to replacing Pydantic AI's internal OpenAI client with a Langfuse-wrapped one, which would risk double-tracing and Responses API compatibility issues.
+
+## Steps
+
+1. Add `_get_tool_definitions(agent)` helper that extracts tool name, description, and parameter JSON schema from the agent's `_function_toolset.tools`.
+2. Add `_log_tool_definitions(agent, episode_id)` helper that creates a `recovery-tool-definitions` Langfuse event with the extracted schemas.
+3. Call `_log_tool_definitions()` inside the `propagate_attributes` context in `_run_with_langfuse()`, before the agent run.
+4. Add unit tests for both helpers.
+5. Update changelog.

--- a/doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md
+++ b/doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md
@@ -1,0 +1,29 @@
+# Implementation session: Log Pydantic AI tool definitions to Langfuse
+
+**Date:** 2026-03-23
+
+**Session ID:** 01TQ9vfjdH5MLG6Dy9ivRuAS
+
+## Summary
+
+Implemented manual logging of Pydantic AI tool definitions to Langfuse as an event in the recovery agent trace.
+
+### User
+
+yes (approved the manual logging approach)
+
+### Assistant
+
+Explored the Pydantic AI source code to find the right API for extracting tool schemas. Found that `agent._function_toolset.tools` is a dict of `Tool` objects, each with a `function_schema.json_schema` property containing the parameters JSON schema and a `description` property. The `tool_def` property returns a `ToolDefinition` with `name`, `description`, and `parameters_json_schema`.
+
+Added two helpers to `episodes/agents/agent.py`:
+- `_get_tool_definitions(agent)` — iterates `agent._function_toolset.tools.values()` and builds a list of `{name, description, parameters}` dicts. Wraps in try/except to return `[]` on error.
+- `_log_tool_definitions(agent, episode_id)` — calls `_get_tool_definitions()`, then uses `langfuse.get_client().create_event()` to log a `recovery-tool-definitions` event with the schemas as input. Silently handles errors.
+
+Modified `_run_with_langfuse()` to call `_log_tool_definitions()` inside the `propagate_attributes` context, before `agent.run()`, so the event appears as a child of the recovery trace.
+
+Created `episodes/tests/test_agent_langfuse.py` with 6 tests:
+- `GetToolDefinitionsTests`: extracts single tool, handles multiple tools, returns empty list on error
+- `LogToolDefinitionsTests`: creates Langfuse event, no-op when no tools, handles Langfuse errors gracefully
+
+All 6 tests pass. Updated changelog and created plan/feature/session documentation.

--- a/doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md
+++ b/doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-23
 
-**Session ID:** 01TQ9vfjdH5MLG6Dy9ivRuAS
+**Session ID:** unavailable
 
 ## Summary
 

--- a/doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md
+++ b/doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-23
 
-**Session ID:** 01TQ9vfjdH5MLG6Dy9ivRuAS
+**Session ID:** unavailable
 
 ## Summary
 

--- a/doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md
+++ b/doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md
@@ -1,0 +1,33 @@
+# Planning session: Log Pydantic AI tool definitions to Langfuse
+
+**Date:** 2026-03-23
+
+**Session ID:** 01TQ9vfjdH5MLG6Dy9ivRuAS
+
+## Summary
+
+Discussed why tool definitions are missing from Langfuse traces and chose the least intrusive approach to fix it.
+
+### User
+
+When looking in Langfuse for the requests sent to ChatGPT by Pydantic AI, I do not see the "tools" element in the input? Should I see it?
+
+### Assistant
+
+Investigated the codebase. The recovery agent uses Pydantic AI's built-in OTel instrumentation (`instrument=True`) which emits OpenTelemetry spans. These capture conversation flow and tool call results but not the `tools` definitions array (the JSON schemas). The pipeline steps use a different path — `langfuse.openai.OpenAI` — which wraps the raw HTTP client and does capture the full request payload including tools. Explained the two layers and confirmed this is expected behavior.
+
+### User
+
+Which one would be less intrusive with the existing code?
+
+### Assistant
+
+Compared two approaches: (1) patching `OpenAIProvider` to accept a Langfuse-wrapped client — risky due to Responses API vs Chat Completions mismatch and potential double-tracing, and (2) manually logging tool definitions as a Langfuse event — just a few lines in `_run_with_langfuse()`. Recommended option 2.
+
+### User
+
+yes
+
+### Assistant
+
+Proceeded to plan implementation: extract tool schemas from `agent._function_toolset.tools` via `Tool.function_schema.json_schema`, log them as a `recovery-tool-definitions` Langfuse event inside the existing `propagate_attributes` context.

--- a/episodes/agents/agent.py
+++ b/episodes/agents/agent.py
@@ -218,7 +218,7 @@ async def _run_agent_async(event: StepFailureEvent) -> RecoveryAgentResult:
             return output
 
 
-def _get_tool_definitions(agent):
+def _get_tool_definitions(agent: Agent) -> list[dict]:
     """Extract tool definitions from the agent's registered function tools.
 
     Returns a list of dicts with ``name``, ``description``, and
@@ -240,7 +240,7 @@ def _get_tool_definitions(agent):
         return []
 
 
-def _log_tool_definitions(agent, episode_id):
+def _log_tool_definitions(agent: Agent, episode_id: int) -> None:
     """Log the agent's tool definitions as a Langfuse event.
 
     Creates a ``recovery-tool-definitions`` event containing the JSON

--- a/episodes/agents/agent.py
+++ b/episodes/agents/agent.py
@@ -218,13 +218,63 @@ async def _run_agent_async(event: StepFailureEvent) -> RecoveryAgentResult:
             return output
 
 
+def _get_tool_definitions(agent):
+    """Extract tool definitions from the agent's registered function tools.
+
+    Returns a list of dicts with ``name``, ``description``, and
+    ``parameters`` (JSON schema) for each tool — the same information
+    that Pydantic AI sends to the model in the ``tools`` array.
+    """
+    try:
+        toolset = agent._function_toolset
+        return [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.function_schema.json_schema,
+            }
+            for tool in toolset.tools.values()
+        ]
+    except Exception:
+        logger.debug("Failed to extract tool definitions from agent", exc_info=True)
+        return []
+
+
+def _log_tool_definitions(agent, episode_id):
+    """Log the agent's tool definitions as a Langfuse event.
+
+    Creates a ``recovery-tool-definitions`` event containing the JSON
+    schemas of all registered tools so they are visible alongside the
+    LLM request traces. Must be called inside a ``propagate_attributes``
+    context.
+    """
+    tool_defs = _get_tool_definitions(agent)
+    if not tool_defs:
+        return
+
+    try:
+        import langfuse
+
+        client = langfuse.get_client()
+        client.create_event(
+            name="recovery-tool-definitions",
+            input={"tools": tool_defs},
+            metadata={
+                "episode_id": episode_id,
+                "tool_count": len(tool_defs),
+            },
+        )
+    except Exception:
+        logger.debug("Failed to log tool definitions to Langfuse", exc_info=True)
+
+
 async def _run_with_langfuse(agent, system_prompt, deps, event):
     """Run the agent, propagating Langfuse session/user attributes when enabled.
 
     Detaches from the parent Langfuse/OTel context (e.g. the pipeline step
     trace) so the recovery agent gets its own independent trace. Screenshots
-    are attached inside the trace context so they appear as child events of
-    the recovery trace.
+    and tool definitions are attached inside the trace context so they appear
+    as child events of the recovery trace.
     """
     from .. import observability
 
@@ -261,6 +311,7 @@ async def _run_with_langfuse(agent, system_prompt, deps, event):
                 with propagate_attributes(
                     session_id=session_id, user_id=user_id, metadata=metadata
                 ):
+                    _log_tool_definitions(agent, event.episode_id)
                     result = await agent.run(**run_kwargs)
                     _attach_screenshots(deps.screenshots, event.episode_id)
                     return result

--- a/episodes/tests/test_agent_langfuse.py
+++ b/episodes/tests/test_agent_langfuse.py
@@ -1,0 +1,132 @@
+"""Tests for Langfuse tool-definition logging in the recovery agent."""
+
+import importlib
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure Django settings are configured before importing app code.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ragtime.settings")
+
+import django
+django.setup()
+
+_has_pydantic_ai = importlib.util.find_spec("pydantic_ai") is not None
+
+
+@unittest.skipUnless(_has_pydantic_ai, "pydantic-ai not installed")
+class GetToolDefinitionsTests(unittest.TestCase):
+    """Tests for _get_tool_definitions()."""
+
+    def test_extracts_tool_names_and_schemas(self):
+        """Returns a list of dicts with name, description, and parameters."""
+        from pydantic_ai import Agent
+
+        agent = Agent("test", deps_type=None)
+
+        @agent.tool_plain
+        def greet(name: str) -> str:
+            """Say hello."""
+            return f"Hello, {name}"
+
+        from episodes.agents.agent import _get_tool_definitions
+
+        defs = _get_tool_definitions(agent)
+
+        self.assertEqual(len(defs), 1)
+        self.assertEqual(defs[0]["name"], "greet")
+        self.assertEqual(defs[0]["description"], "Say hello.")
+        self.assertIn("properties", defs[0]["parameters"])
+        self.assertIn("name", defs[0]["parameters"]["properties"])
+
+    def test_returns_empty_list_on_error(self):
+        """Gracefully returns [] when the agent has no _function_toolset."""
+        from episodes.agents.agent import _get_tool_definitions
+
+        fake_agent = MagicMock(spec=[])  # no attributes at all
+        self.assertEqual(_get_tool_definitions(fake_agent), [])
+
+    def test_handles_multiple_tools(self):
+        """Extracts definitions for all registered tools."""
+        from pydantic_ai import Agent
+
+        agent = Agent("test", deps_type=None)
+
+        @agent.tool_plain
+        def tool_a(x: int) -> str:
+            """First tool."""
+            return str(x)
+
+        @agent.tool_plain
+        def tool_b(y: str) -> str:
+            """Second tool."""
+            return y
+
+        from episodes.agents.agent import _get_tool_definitions
+
+        defs = _get_tool_definitions(agent)
+        names = {d["name"] for d in defs}
+        self.assertEqual(names, {"tool_a", "tool_b"})
+
+
+@unittest.skipUnless(_has_pydantic_ai, "pydantic-ai not installed")
+class LogToolDefinitionsTests(unittest.TestCase):
+    """Tests for _log_tool_definitions()."""
+
+    @patch("episodes.agents.agent.langfuse", create=True)
+    def test_creates_langfuse_event(self, mock_langfuse_module):
+        """Logs tool definitions as a recovery-tool-definitions event."""
+        from pydantic_ai import Agent
+
+        agent = Agent("test", deps_type=None)
+
+        @agent.tool_plain
+        def my_tool(x: int) -> str:
+            """Do something."""
+            return str(x)
+
+        mock_client = MagicMock()
+        mock_langfuse_module.get_client.return_value = mock_client
+
+        # Patch the import inside _log_tool_definitions
+        with patch.dict("sys.modules", {"langfuse": mock_langfuse_module}):
+            from episodes.agents.agent import _log_tool_definitions
+
+            _log_tool_definitions(agent, episode_id=42)
+
+        mock_client.create_event.assert_called_once()
+        call_kwargs = mock_client.create_event.call_args[1]
+        self.assertEqual(call_kwargs["name"], "recovery-tool-definitions")
+        self.assertEqual(len(call_kwargs["input"]["tools"]), 1)
+        self.assertEqual(call_kwargs["input"]["tools"][0]["name"], "my_tool")
+        self.assertEqual(call_kwargs["metadata"]["episode_id"], 42)
+        self.assertEqual(call_kwargs["metadata"]["tool_count"], 1)
+
+    def test_no_op_when_no_tools(self):
+        """Does not call Langfuse when agent has no extractable tools."""
+        from episodes.agents.agent import _log_tool_definitions
+
+        fake_agent = MagicMock(spec=[])  # no _function_toolset
+
+        # Should not raise
+        _log_tool_definitions(fake_agent, episode_id=1)
+
+    @patch("episodes.agents.agent.langfuse", create=True)
+    def test_handles_langfuse_error_gracefully(self, mock_langfuse_module):
+        """Swallows exceptions from Langfuse client."""
+        from pydantic_ai import Agent
+
+        agent = Agent("test", deps_type=None)
+
+        @agent.tool_plain
+        def failing_tool(x: int) -> str:
+            """A tool."""
+            return str(x)
+
+        mock_langfuse_module.get_client.side_effect = RuntimeError("connection failed")
+
+        with patch.dict("sys.modules", {"langfuse": mock_langfuse_module}):
+            from episodes.agents.agent import _log_tool_definitions
+
+            # Should not raise
+            _log_tool_definitions(agent, episode_id=1)

--- a/episodes/tests/test_agent_langfuse.py
+++ b/episodes/tests/test_agent_langfuse.py
@@ -1,17 +1,16 @@
 """Tests for Langfuse tool-definition logging in the recovery agent."""
 
-import importlib
-import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Ensure Django settings are configured before importing app code.
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ragtime.settings")
+try:
+    from pydantic_ai import Agent
 
-import django
-django.setup()
+    from episodes.agents.agent import _get_tool_definitions, _log_tool_definitions
 
-_has_pydantic_ai = importlib.util.find_spec("pydantic_ai") is not None
+    _has_pydantic_ai = True
+except ImportError:
+    _has_pydantic_ai = False
 
 
 @unittest.skipUnless(_has_pydantic_ai, "pydantic-ai not installed")
@@ -20,16 +19,12 @@ class GetToolDefinitionsTests(unittest.TestCase):
 
     def test_extracts_tool_names_and_schemas(self):
         """Returns a list of dicts with name, description, and parameters."""
-        from pydantic_ai import Agent
-
         agent = Agent("test", deps_type=None)
 
         @agent.tool_plain
         def greet(name: str) -> str:
             """Say hello."""
             return f"Hello, {name}"
-
-        from episodes.agents.agent import _get_tool_definitions
 
         defs = _get_tool_definitions(agent)
 
@@ -41,15 +36,11 @@ class GetToolDefinitionsTests(unittest.TestCase):
 
     def test_returns_empty_list_on_error(self):
         """Gracefully returns [] when the agent has no _function_toolset."""
-        from episodes.agents.agent import _get_tool_definitions
-
         fake_agent = MagicMock(spec=[])  # no attributes at all
         self.assertEqual(_get_tool_definitions(fake_agent), [])
 
     def test_handles_multiple_tools(self):
         """Extracts definitions for all registered tools."""
-        from pydantic_ai import Agent
-
         agent = Agent("test", deps_type=None)
 
         @agent.tool_plain
@@ -61,8 +52,6 @@ class GetToolDefinitionsTests(unittest.TestCase):
         def tool_b(y: str) -> str:
             """Second tool."""
             return y
-
-        from episodes.agents.agent import _get_tool_definitions
 
         defs = _get_tool_definitions(agent)
         names = {d["name"] for d in defs}
@@ -76,8 +65,6 @@ class LogToolDefinitionsTests(unittest.TestCase):
     @patch("episodes.agents.agent.langfuse", create=True)
     def test_creates_langfuse_event(self, mock_langfuse_module):
         """Logs tool definitions as a recovery-tool-definitions event."""
-        from pydantic_ai import Agent
-
         agent = Agent("test", deps_type=None)
 
         @agent.tool_plain
@@ -88,10 +75,7 @@ class LogToolDefinitionsTests(unittest.TestCase):
         mock_client = MagicMock()
         mock_langfuse_module.get_client.return_value = mock_client
 
-        # Patch the import inside _log_tool_definitions
         with patch.dict("sys.modules", {"langfuse": mock_langfuse_module}):
-            from episodes.agents.agent import _log_tool_definitions
-
             _log_tool_definitions(agent, episode_id=42)
 
         mock_client.create_event.assert_called_once()
@@ -104,8 +88,6 @@ class LogToolDefinitionsTests(unittest.TestCase):
 
     def test_no_op_when_no_tools(self):
         """Does not call Langfuse when agent has no extractable tools."""
-        from episodes.agents.agent import _log_tool_definitions
-
         fake_agent = MagicMock(spec=[])  # no _function_toolset
 
         # Should not raise
@@ -114,8 +96,6 @@ class LogToolDefinitionsTests(unittest.TestCase):
     @patch("episodes.agents.agent.langfuse", create=True)
     def test_handles_langfuse_error_gracefully(self, mock_langfuse_module):
         """Swallows exceptions from Langfuse client."""
-        from pydantic_ai import Agent
-
         agent = Agent("test", deps_type=None)
 
         @agent.tool_plain
@@ -126,7 +106,5 @@ class LogToolDefinitionsTests(unittest.TestCase):
         mock_langfuse_module.get_client.side_effect = RuntimeError("connection failed")
 
         with patch.dict("sys.modules", {"langfuse": mock_langfuse_module}):
-            from episodes.agents.agent import _log_tool_definitions
-
             # Should not raise
             _log_tool_definitions(agent, episode_id=1)


### PR DESCRIPTION
## Summary

- Add `_get_tool_definitions()` and `_log_tool_definitions()` helpers to `episodes/agents/agent.py` that extract tool schemas from the Pydantic AI agent and log them as a `recovery-tool-definitions` Langfuse event inside the recovery trace
- Pydantic AI's OTel instrumentation captures conversation flow but omits the `tools` JSON schemas sent to the model — this fills that gap so tool definitions are visible in Langfuse alongside the LLM request traces
- 6 unit tests covering schema extraction and Langfuse event creation

## Test plan

- [x] `uv run python manage.py test episodes.tests.test_agent_langfuse` — all 6 tests pass
- [ ] Trigger a recovery agent run (e.g. via a scraping failure) and verify the `recovery-tool-definitions` event appears in the Langfuse trace with full JSON schemas for all 11 tools

## Documentation

- [[Plan](https://claude.ai/claude-code-desktop/doc/plans/2026-03-23-add-tools-langfuse.md)](doc/plans/2026-03-23-add-tools-langfuse.md)
- [[Feature](https://claude.ai/claude-code-desktop/doc/features/2026-03-23-add-tools-langfuse.md)](doc/features/2026-03-23-add-tools-langfuse.md)
- [[Planning session](https://claude.ai/claude-code-desktop/doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md)](doc/sessions/2026-03-23-add-tools-langfuse-planning-session.md)
- [[Implementation session](https://claude.ai/claude-code-desktop/doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md)](doc/sessions/2026-03-23-add-tools-langfuse-implementation-session.md)