### PR TITLE
Add .continue/checks/ for AI-powered PR review

### DIFF
--- a/.continue/checks/asgi-wsgi-scott.md
+++ b/.continue/checks/asgi-wsgi-scott.md
@@ -1,0 +1,104 @@
+---
+name: ASGI vs WSGI Awareness for Scott
+description: Anything touching Scott's chat path must be tested under uvicorn (ASGI). runserver does not load asgi.py and will silently 404 the AG-UI endpoint.
+---
+
+# ASGI vs WSGI Awareness for Scott
+
+## Context
+
+Scott is a Pydantic AI agent exposed as an AG-UI ASGI app, mounted
+inside Django at `/chat/agent/` via a path dispatcher in `ragtime/asgi.py`.
+
+The trap: Django's `manage.py runserver` runs in **WSGI mode** by
+default. WSGI never loads `ragtime/asgi.py`, so the path dispatcher
+that routes `/chat/agent/` to the Pydantic AI app is never installed.
+The chat UI appears to load, then `/chat/agent/` returns 404 or a
+plain Django response — and the developer thinks the bug is in their
+streaming code.
+
+The required dev command for Scott work is:
+
+```bash
+uv run uvicorn ragtime.asgi:application --host 127.0.0.1 --port 8000
+```
+
+This is documented in `AGENTS.md` and called out as a footnote in the
+commands section. It is easy to forget.
+
+## What to Check
+
+### 1. Chat changes must show evidence of ASGI testing
+
+If the diff touches any of:
+
+- `ragtime/asgi.py`
+- `chat/` (views, routing, agent definition, templates that hit
+  `/chat/agent/`)
+- The AG-UI mounted app or its tool definitions
+- `frontend/` integration with `@assistant-ui/react-ag-ui`
+
+…then the PR description, test plan, or session transcript must show
+the developer actually exercised the change under `uvicorn`. Acceptable
+evidence:
+
+- A "Verification" section naming the `uvicorn ragtime.asgi:application`
+  command and the observed behaviour.
+- A logged test run hitting `/chat/agent/` with a streaming response.
+- A frontend session transcript showing the chat working end-to-end.
+
+A test plan that just says "ran `manage.py runserver`" for a Scott
+change is a fail — the change was almost certainly not exercised.
+
+### 2. Don't add code that assumes WSGI-only middleware
+
+Anything that subclasses `MiddlewareMixin` or assumes the
+`request.META`/`get_response` WSGI shapes can break under ASGI. New
+middleware must either be ASGI-aware (async-capable) or be explicitly
+scoped to non-Scott paths.
+
+**BAD** — a new sync-only middleware that runs on every request and
+calls `time.sleep(0.1)` while the chat stream is open. Blocks the
+ASGI event loop.
+
+**GOOD** — `async def __call__` middleware, or a middleware whose
+`process_request` short-circuits on `/chat/agent/`.
+
+### 3. New `/chat/agent/`-adjacent paths need dispatcher updates
+
+If the diff adds a new ASGI-mounted endpoint (another agent, a
+websocket), confirm `ragtime/asgi.py`'s dispatcher routes it. Mounting
+in `urls.py` alone is insufficient for ASGI sub-apps.
+
+### 4. Doc commands must keep both invocations distinct
+
+If the diff edits the "Commands" section of `README.md`, `AGENTS.md`,
+`CLAUDE.md`, or `doc/README.md`, both commands must remain present and
+clearly labelled:
+
+- `runserver` — WSGI, fine for admin / episodes / ingestion
+- `uvicorn ragtime.asgi:application` — required for Scott
+
+Removing or merging them confuses future developers and AI agents.
+
+### 5. Tests for chat behaviour
+
+Django's `TestCase` and `Client` are WSGI. Tests that hit
+`/chat/agent/` need `AsyncClient` or a direct call into the AG-UI app —
+not `self.client.get("/chat/agent/")`. Flag chat tests using the
+sync client.
+
+## Key Files
+
+- `ragtime/asgi.py` — path dispatcher
+- `ragtime/wsgi.py` — for contrast; `/chat/agent/` is *not* here
+- `chat/` — Scott's views, agent, tools
+- `frontend/` — AG-UI client wiring
+- `README.md`, `AGENTS.md`, `CLAUDE.md`, `doc/README.md` — command docs
+
+## Exclusions
+
+- Pure admin-only changes (admin runs fine on WSGI).
+- Episode pipeline / ingestion changes that don't touch `/chat/agent/`.
+- Frontend-only changes that don't change the request path or streaming
+  contract (e.g. CSS, copy edits inside the chat island).

--- a/.continue/checks/branching-and-pr-strategy.md
+++ b/.continue/checks/branching-and-pr-strategy.md
@@ -1,0 +1,110 @@
+---
+name: Branching & PR Strategy
+description: No direct commits to main. Feature branches off latest main. Rebase merge only — squash and merge-commit are forbidden on this repo.
+---
+
+# Branching & PR Strategy
+
+## Context
+
+AGENTS.md is unambiguous on the workflow:
+
+> Before beginning any new work, always: verify we are on the `main`
+> branch and switch to it if not, pull latest changes (`git pull --rebase`).
+> All new features and fixes must be implemented in a dedicated branch
+> off `main`. Never commit directly to `main`. When creating PRs, use
+> the rebase strategy. Squash and merge-commit strategies are not
+> allowed on this repository.
+
+Why it matters:
+
+- The session-transcript / plan / feature-doc bundle is per-PR; commits
+  on `main` would smear that across history.
+- Rebase merges keep the linear history that `git log` and `git blame`
+  rely on. A squash would collapse the carefully-staged commits within
+  a feature branch (often with their own session boundaries) into a
+  single tombstone.
+
+A linter cannot enforce branch discipline before push. This check is
+the human-judgement gate.
+
+## What to Check
+
+### 1. PR is not from main
+
+The PR must be from a feature branch (e.g. `feature/scott-citations`,
+`fix/resolver-deadlock`) into `main`, never `main` → `main` and never
+some long-lived `develop` branch into `main`. If the PR is from `main`
+or the branch name is generic (`patch-1`, `update`, `tmp`), flag it
+and request a rename.
+
+### 2. Branch is up-to-date with main (rebased)
+
+Confirm the branch has been rebased onto current `main`, not merged
+from `main`. Tells:
+
+- The PR commits show as a clean linear sequence on top of `main`'s
+  tip, not interleaved with merge commits.
+- No commits with messages like `Merge branch 'main' into feature/...`.
+
+If `main` has moved, the author should `git rebase main` and
+force-push, not `git merge main`.
+
+### 3. No merge commits inside the branch
+
+Inside the feature branch, every commit should be a real change. Merge
+commits from `main`, or from an intermediate branch, will block a
+clean rebase merge and pollute the linear history. Flag any merge
+commit in the PR's commit list.
+
+### 4. Commit messages aren't squash-shaped
+
+Because the merge strategy is rebase, every individual commit lands on
+`main` as-is. Commit messages should be self-contained and useful in
+isolation, not titled "wip", "fix", "address review", or "more
+changes" expecting a squash to clean them up. If the PR has those
+shapes, ask the author to `git rebase -i` and tidy up before merge.
+
+(Note: AGENTS.md forbids using `-i` flag on `git rebase` from inside
+agent sessions — this is a request for the human author, not something
+the agent runs.)
+
+### 5. Documentation commit lives in the PR
+
+AGENTS.md: "The commit for a given feature MUST contain the plan, the
+feature documentation, and both session transcripts (planning and
+implementation)." With rebase merge, those commits land on `main`
+verbatim. Confirm the docs are in the same PR — not a separate
+follow-up PR — so the rebased history pairs each feature commit with
+its docs.
+
+### 6. PR description anticipates rebase merge
+
+Reviewers should see, somewhere in the PR description or template,
+that the merge button used will be **Rebase and merge**. If the repo
+settings somehow show squash/merge-commit options as the default, flag
+that as a settings bug to fix at the repo level — but the PR itself
+should not be merged any other way.
+
+### 7. Don't commit to main from agent sessions
+
+If a session transcript shows the agent committed directly to `main`
+(no `git checkout -b`, just `git commit` while on `main`), that is a
+process failure and must be called out. The fix is to move the commits
+to a feature branch and reset `main` to its upstream tip — but this is
+a destructive operation and the human must do it.
+
+## Key Files
+
+- `.git/` state (branch, log, config) — inspect via `git` rather than
+  reading files
+- `AGENTS.md` — the source of truth for these rules
+- `.github/` — repo settings, PR templates, CODEOWNERS
+
+## Exclusions
+
+- Trivial typo fixes that GitHub's web UI made via "Edit on GitHub" —
+  these still go through a PR but the branch may be auto-named. Just
+  confirm it was rebase-merged.
+- Initial repo bootstrap commits (before the rules existed). Use
+  judgement on the date of the violation.

--- a/.continue/checks/comment-discipline.md
+++ b/.continue/checks/comment-discipline.md
@@ -1,0 +1,107 @@
+---
+name: Comment Discipline
+description: Comments must explain non-obvious WHY. No narration of the current task, no restating WHAT the code does, no rotting references to callers or issues.
+---
+
+# Comment Discipline
+
+## Context
+
+This codebase deliberately keeps comments rare. The repo's coding
+guidelines (in `CLAUDE.md` / `AGENTS.md` and the wider Claude Code
+defaults) state:
+
+- Default to **no comments**. Add one only when the WHY is non-obvious:
+  a hidden constraint, a subtle invariant, a workaround for a specific
+  bug, behaviour that would surprise a reader.
+- Don't explain WHAT the code does — well-named identifiers do that.
+- Don't reference the current task, fix, or callers ("used by X",
+  "added for the Y flow", "handles the case from issue #123") — those
+  belong in the PR description and rot as the codebase evolves.
+- No multi-paragraph docstrings or multi-line comment blocks. One short
+  line is the cap.
+- No `# removed code` / `# was: ...` tombstones. The git history is the
+  history.
+
+This is a judgment-heavy rule. A formatter cannot tell a useful WHY
+comment apart from a noisy WHAT comment. That is what this check is for.
+
+## What to Check
+
+### 1. Reject WHAT comments
+
+If the comment paraphrases what the next line obviously does, it should
+go.
+
+**BAD**
+
+```python
+# Loop over episodes and update status
+for episode in episodes:
+    episode.status = "ready"
+    episode.save()
+```
+
+**GOOD** — drop the comment. The code is self-evident.
+
+### 2. Reject task/PR/caller references
+
+Comments referencing the moment of writing rot the fastest. They
+mislead readers months later when callers move or issues close.
+
+**BAD**
+
+```python
+# Added in PR #427 for the Wikidata enrichment workflow
+# Used by chat/views.py
+def hydrate_entities(...): ...
+```
+
+**GOOD** — drop both. If the function genuinely has a non-obvious
+constraint (e.g. "must run inside a DBOS step because it relies on
+checkpoint replay"), keep that single line.
+
+### 3. Reject tombstones
+
+Lines like `# removed: old impl`, `# was: foo()`, `# TODO: rewrite this`
+without a tracked owner/date should be deleted, not added.
+
+### 4. Keep load-bearing WHY comments
+
+Some comments earn their keep. Don't flag these:
+
+- A subtle invariant: `# keys must be sorted to avoid A→B / B→A deadlock`
+- A workaround tied to a specific bug: `# Qdrant 1.10 returns float ids; cast to int`
+- A surprising default: `# default 30 — Wikidata 429s above 1 req/s`
+- An external contract: `# AG-UI requires the 'tool_use' chunk before 'text'`
+
+The shape that signals "load-bearing": short, names a constraint or
+external fact, would surprise a reader skimming the code.
+
+### 5. Multi-line comment blocks
+
+Module docstrings explaining architecture (like the header in
+`episodes/vector_store.py`) are fine. Inline multi-paragraph blocks
+above functions are not — collapse to one line or delete.
+
+### 6. Empty / placeholder docstrings
+
+`"""TODO: docstring"""` and `"""."""` are noise. Delete them.
+
+## Key Files
+
+Apply across the diff. Especially noisy areas historically:
+
+- `episodes/resolver.py`
+- `episodes/workflows.py`
+- `chat/` view code
+- New management commands under `*/management/commands/`
+
+## Exclusions
+
+- Module-level architectural docstrings that genuinely orient a reader
+  to a non-trivial file (the header of `episodes/vector_store.py` is a
+  fair example).
+- Tests, where descriptive `# Given / # When / # Then` comments can
+  improve readability — judgement call, lean permissive.
+- Generated code / migrations.

--- a/.continue/checks/entity-creation-race-safety.md
+++ b/.continue/checks/entity-creation-race-safety.md
@@ -1,0 +1,104 @@
+---
+name: Entity Creation Race Safety
+description: All Entity row creation must go through get_or_create with a sorted advisory lock — never bare Entity.objects.create().
+---
+
+# Entity Creation Race Safety
+
+## Context
+
+Pipeline episodes run in parallel (default `RAGTIME_EPISODE_CONCURRENCY=4`).
+The resolver was the source of a real production deadlock when parallel
+episodes shared entity names across types — see commit `4b69d9e` ("Fix
+resolver deadlock when parallel episodes share entity names across types").
+
+The fix codified a single safe pattern, in `episodes/resolver.py`:
+
+1. Acquire a deterministic Postgres advisory lock on
+   `(entity_type, name)` — `pg_advisory_xact_lock(hashtextextended(key, 0))`.
+2. **Sort the keys before locking** when taking multiple locks in the
+   same transaction, to prevent inverse-order deadlocks.
+3. Use `Entity.objects.get_or_create(...)`, with an `IntegrityError`
+   fallback for the unlikely-but-possible race after the lock.
+
+The wrapper that does this is `_get_or_create_entity(entity_type, name, mbid)`
+in `episodes/resolver.py`. Bypassing it — even "just this once" — re-opens
+the deadlock window.
+
+## What to Check
+
+### 1. No bare Entity.objects.create
+
+Search the diff for `Entity.objects.create(`. Any new occurrence outside
+tests is a fail. Use `_get_or_create_entity(...)` from
+`episodes/resolver.py` instead, or extract a similar helper if the call
+site genuinely can't import it.
+
+**BAD**
+
+```python
+entity = Entity.objects.create(entity_type=etype, name=name)
+```
+
+**GOOD**
+
+```python
+from episodes.resolver import _get_or_create_entity
+entity, _created = _get_or_create_entity(etype, name)
+```
+
+### 2. Multi-key locks must be sorted
+
+If new code takes more than one advisory lock in a single transaction,
+the keys must be sorted before iteration. Unsorted locks across parallel
+workers cause classic A→B / B→A deadlocks.
+
+**BAD**
+
+```python
+for key in entity_keys:                  # arbitrary order
+    cur.execute("SELECT pg_advisory_xact_lock(hashtextextended(%s, 0))", (key,))
+```
+
+**GOOD**
+
+```python
+for key in sorted(entity_keys):
+    cur.execute("SELECT pg_advisory_xact_lock(hashtextextended(%s, 0))", (key,))
+```
+
+### 3. Don't downgrade xact_lock to non-xact
+
+`pg_advisory_xact_lock` releases automatically at transaction end.
+`pg_advisory_lock` does not — forgetting an unlock leaks the lock for
+the lifetime of the connection. Flag any switch from `xact` to non-`xact`.
+
+### 4. Lock keys must include entity_type
+
+The deadlock fix specifically broadened the key to `(entity_type, name)`
+because two episodes resolving "Miles Davis" as both Person and Artist
+would hold disjoint rows but contend on the same name string. Don't
+narrow the key back to just `name`.
+
+### 5. New entity-creating code paths
+
+If the diff introduces a new place that creates `Entity` rows (e.g. a
+new admin action, a backfill management command, a new resolver mode),
+either:
+
+- Route it through `_get_or_create_entity`, OR
+- Document why this path is single-writer (e.g. "this command is run
+  manually, never concurrently") in a comment, and confirm that's
+  actually true.
+
+## Key Files
+
+- `episodes/resolver.py` — canonical pattern, `_get_or_create_entity`
+- `episodes/models.py` — `Entity` model, unique constraint
+- Any new file under `episodes/` that imports `Entity`
+
+## Exclusions
+
+- Tests using `Entity.objects.create` directly inside transactions
+  scoped to a single test (no concurrency).
+- Migrations using `RunPython` with a single-writer assumption.

--- a/.continue/checks/env-var-sync.md
+++ b/.continue/checks/env-var-sync.md
@@ -1,0 +1,74 @@
+---
+name: RAGTIME_* Env Var Sync
+description: New, renamed, or removed RAGTIME_* env vars must be reflected in .env.sample and the configure wizard.
+---
+
+# RAGTIME_* Env Var Sync
+
+## Context
+
+All runtime configuration uses the `RAGTIME_*` prefix and is loaded via
+`python-dotenv` from a `.env` file. Two surfaces must stay in sync with the
+code that reads these vars:
+
+- `.env.sample` — the canonical "what can I configure?" reference checked
+  into the repo
+- `core/management/commands/configure.py` — the interactive setup wizard
+  users run via `uv run python manage.py configure`
+
+AGENTS.md is explicit: "Whenever a `RAGTIME_*` environment variable is
+added, changed, or removed, update `.env.sample` and the configuration
+wizard accordingly." Drift here breaks new-developer onboarding silently
+— the app boots, but with the wrong defaults or with mysterious missing
+features.
+
+## What to Check
+
+### 1. Newly-read env vars must appear in both surfaces
+
+If the diff introduces a new `os.environ`, `os.getenv`, `env(...)`, or
+`settings.RAGTIME_*` reference for a previously-unknown var, confirm:
+
+- `.env.sample` has a line for the new var with a sensible placeholder
+  and a brief comment explaining what it controls.
+- `core/management/commands/configure.py` prompts for it (if user-facing)
+  or has a clear reason it doesn't (e.g. internal-only, derived).
+
+**BAD** — PR adds `RAGTIME_RESOLVER_LLM_TIMEOUT = int(os.getenv(...))` in
+`episodes/resolver.py` but `.env.sample` and `configure.py` are unchanged.
+
+**GOOD** — same code change, plus a `.env.sample` entry like
+`# Timeout (seconds) for the resolver LLM call. Default: 30.` and a
+matching prompt in `configure.py`.
+
+### 2. Renames and removals must purge stale entries
+
+If an env var is renamed (e.g. `RAGTIME_FOO` → `RAGTIME_BAR`) or removed,
+both `.env.sample` and `configure.py` must drop the old name. Leaving the
+old key around tells users to set a value that does nothing.
+
+### 3. Default-value changes are user-visible
+
+If the default for an existing var changes in code, the comment/example
+in `.env.sample` should reflect the new default so users copying the
+sample don't get surprising behaviour.
+
+### 4. Secret-shaped vars must not leak example values
+
+For API keys, tokens, and passwords, `.env.sample` should use a clearly
+placeholder value (`your-anthropic-api-key`, `changeme`) — never a real
+key, even a revoked one. Flag any commit that adds a value matching
+`sk-`, `pk-`, `xoxb-`, or other obvious key prefixes.
+
+## Key Files
+
+- `.env.sample` — template
+- `core/management/commands/configure.py` — interactive wizard
+- `ragtime/settings.py` and any `episodes/`, `chat/`, `core/` module
+  reading `RAGTIME_*` vars
+
+## Exclusions
+
+- Internal feature flags that are intentionally undocumented (rare;
+  require a comment in code explaining why).
+- Test-only env vars set in `tests/` and never read by production code.

--- a/.continue/checks/feature-pr-docs.md
+++ b/.continue/checks/feature-pr-docs.md
@@ -1,0 +1,127 @@
+---
+name: Feature PR Documentation Bundle
+description: Non-trivial feature PRs must ship the plan, feature doc, both session transcripts, and a changelog entry — with correct metadata format.
+---
+
+# Feature PR Documentation Bundle
+
+## Context
+
+This repo treats documentation as part of the PR, not an afterthought.
+AGENTS.md mandates that the commit for a feature contains:
+
+- The plan, in `doc/plans/YYYY-MM-DD-my-feature.md`
+- The feature doc, in `doc/features/YYYY-MM-DD-my-feature.md`
+- The planning session transcript, ending in `-planning-session.md`
+- The implementation session transcript, ending in `-implementation-session.md`
+- A `CHANGELOG.md` entry (Keep a Changelog format, dated section headers)
+
+There is also a strict metadata format: every doc starts with a
+`# Title` on the first line; metadata lines (`**Date:**`,
+`**Session ID:**`) come immediately after, separated by blank lines.
+Session transcripts must use a real Claude Code session UUID, not
+"current session" or worktree names.
+
+A linter cannot judge whether a PR is "a feature" — that requires reading
+the diff. This check exists for that judgment call.
+
+## What to Check
+
+### 1. Classify the PR
+
+Read the PR title, description, and diff. Decide if this is a feature /
+significant change, a bug fix, a refactor, or docs/chore. Only features
+and significant changes need the full bundle. State your classification
+explicitly so the author can push back.
+
+Heuristics for "feature / significant change":
+- Adds or removes a pipeline step, provider, model, or admin view
+- Introduces a new `RAGTIME_*` env var that gates user-visible behaviour
+- Adds a new external dependency or service integration
+- Changes Scott's prompt, retrieval, or tool-calling contract
+- New management command intended for routine use
+
+Heuristics for "no bundle needed":
+- Pure bug fix with a test
+- Internal refactor with no behaviour change
+- Dependency bumps
+- Doc-only PRs
+
+### 2. If feature: all four artefacts present
+
+The PR must contain new files at:
+
+- `doc/plans/YYYY-MM-DD-<slug>.md`
+- `doc/features/YYYY-MM-DD-<slug>.md`
+- `doc/sessions/YYYY-MM-DD-<slug>-planning-session.md`
+- `doc/sessions/YYYY-MM-DD-<slug>-implementation-session.md`
+
+…with **the same date prefix and slug** across all four. Mismatched
+slugs make these impossible to find later.
+
+### 3. Metadata format is correct
+
+For every new doc file, verify:
+
+- Line 1 is `# <Title>` — not frontmatter, not a blank line.
+- Metadata lines (`**Date:** YYYY-MM-DD`, and for transcripts
+  `**Session ID:** <uuid>`) come immediately after the title, before any
+  `## Section`.
+- A blank line separates each metadata line so they render as separate
+  paragraphs.
+- Session ID is a real UUID, not `current session`, `unavailable` (unless
+  truly unrecoverable), or a worktree name.
+
+**BAD**
+
+```markdown
+**Date:** 2026-04-30
+# My Feature
+**Session ID:** current session
+## Summary
+```
+
+**GOOD**
+
+```markdown
+# My Feature
+
+**Date:** 2026-04-30
+
+**Session ID:** a150a5a3-218f-44b4-a02b-cf90912619d7
+
+## Summary
+```
+
+### 4. Changelog entry
+
+`CHANGELOG.md` must have a new bullet under a dated section
+(`## YYYY-MM-DD`), grouped by category (`### Added`, `### Changed`, etc.),
+with links to the plan, feature doc, and both session transcripts.
+Newest dates go first; existing same-day sections get appended to, not
+duplicated.
+
+### 5. Implementation transcript covers PR review
+
+AGENTS.md requires the implementation transcript to include all
+interactions up to and including PR review feedback and follow-up
+changes. If the PR has had review rounds, confirm those rounds appear
+in the transcript — not just the initial implementation.
+
+### 6. User messages are verbatim
+
+Spot-check the transcript: user sections should read like real,
+unedited messages (typos, casual phrasing, context). If they read like
+clean prose summaries, they have been paraphrased and need fixing.
+
+## Key Files
+
+- `doc/plans/`, `doc/features/`, `doc/sessions/`
+- `CHANGELOG.md`
+- The diff itself (to classify the PR)
+
+## Exclusions
+
+- Bug fixes, refactors, dependency bumps, doc-only PRs.
+- Hot-fixes explicitly tagged as urgent in the PR description (note as
+  follow-up debt, don't block).

--- a/.continue/checks/gh-api-shell-escaping.md
+++ b/.continue/checks/gh-api-shell-escaping.md
@@ -1,0 +1,127 @@
+---
+name: gh api Shell Escaping & Endpoints
+description: gh api invocations must use heredocs for bodies with backticks/specials, and must hit the correct endpoints for PR comments and replies.
+---
+
+# gh api Shell Escaping & Endpoints
+
+## Context
+
+`gh api` is the standard way scripts and agents in this repo interact
+with GitHub — replying to PR review comments, fetching review threads,
+posting issue comments. AGENTS.md documents two recurring failure modes:
+
+1. **Shell escaping.** zsh interprets backticks as command substitution.
+   A `gh api ... -f body="see \`foo()\`"` will try to *execute* `foo()`
+   on the local shell. The fix is `$(cat <<'EOF' ... EOF)` heredocs with
+   the quoted `'EOF'` delimiter (which disables expansion entirely).
+
+2. **Wrong endpoints.** GitHub's API has several confusable endpoints:
+   - PR review comments (file-anchored): `repos/O/R/pulls/N/comments`
+   - PR general comments (timeline): `repos/O/R/issues/N/comments`
+   - PR reviews (the review objects, not their comments):
+     `repos/O/R/pulls/N/reviews`
+   - Replying to a review comment: POST to
+     `repos/O/R/pulls/N/comments` with `-F in_reply_to=COMMENT_ID`.
+     There is **no** `/replies` sub-endpoint on individual comments —
+     that returns 404.
+
+These are easy to get subtly wrong (the call succeeds against the wrong
+resource, or the comment lands on the wrong thread). A linter cannot
+catch them. This check is for that.
+
+## What to Check
+
+### 1. Bodies with backticks/specials must use heredocs
+
+If a `gh api ... -f body="..."` invocation contains backticks, dollar
+signs, double quotes, or `!`, it must be rewritten as a heredoc:
+
+**BAD**
+
+```bash
+gh api repos/O/R/pulls/1/comments \
+  -f body="See `process_episode()` for the fix"
+```
+
+**GOOD**
+
+```bash
+gh api repos/O/R/pulls/1/comments \
+  -f body="$(cat <<'EOF'
+See `process_episode()` for the fix
+EOF
+)" \
+  -F in_reply_to=12345
+```
+
+Note the **quoted** `'EOF'` — without the quotes, `$VAR` and backticks
+are still expanded inside the heredoc.
+
+### 2. Reply endpoints
+
+A "reply to a review comment" must POST to the pulls comments endpoint
+with `-F in_reply_to=...`. Reject any URL containing
+`/comments/<id>/replies` — that path does not exist.
+
+**BAD**
+
+```bash
+gh api repos/O/R/pulls/1/comments/12345/replies -f body="thanks"
+# 404
+```
+
+**GOOD**
+
+```bash
+gh api repos/O/R/pulls/1/comments \
+  -f body="thanks" \
+  -F in_reply_to=12345
+```
+
+### 3. Review-comment vs issue-comment confusion
+
+Reading or posting to the wrong endpoint silently lands on the wrong
+thread. Spot-check intent vs URL:
+
+- Fetching the file-anchored review comments on a PR:
+  `repos/O/R/pulls/N/comments` ✓
+- Fetching the timeline conversation on a PR:
+  `repos/O/R/issues/N/comments` ✓ (because PRs are issues for the
+  comment timeline)
+- Listing reviews (the review summaries themselves):
+  `repos/O/R/pulls/N/reviews` ✓
+
+If the script claims to "fetch all PR comments" but only hits
+`/pulls/N/comments`, it's missing the issue timeline — flag it.
+
+### 4. POST/PATCH/DELETE warrant extra care
+
+Any non-GET `gh api` call (anything with `-f`, `-F`, `--method POST/PATCH/DELETE`,
+or `-X`) is doing a side-effecting action against GitHub. Confirm:
+
+- The body is escaped per rule (1).
+- The endpoint is right per rules (2)–(3).
+- For destructive actions (closing PRs, deleting branches, dismissing
+  reviews) there is a clear reason in the surrounding context.
+
+### 5. Don't paper over with `--no-verify`-style flags
+
+If a `gh` call is failing and the proposed fix adds `-H` headers to
+bypass validation, or skips `--method` checks, prefer fixing the URL
+or body instead.
+
+## Key Files
+
+- Anywhere under `scripts/`, `core/management/commands/`,
+  `.github/workflows/`, or shell snippets in `doc/` that invoke `gh`.
+- Code blocks in markdown docs that show users `gh api` recipes — those
+  get copied verbatim and need to be correct.
+
+## Exclusions
+
+- `gh pr view`, `gh pr create`, `gh issue view` and other high-level
+  `gh` subcommands: those don't have the body-escaping problem because
+  they read from `--body-file` or stdin, and they hit the right
+  endpoints by construction.
+- Read-only `gh api` GETs with no `-f`/`-F` body.

--- a/.continue/checks/pipeline-step-sync.md
+++ b/.continue/checks/pipeline-step-sync.md
@@ -1,0 +1,82 @@
+---
+name: Pipeline Step Documentation Sync
+description: When the 10-step ingestion pipeline changes, README.md, doc/README.md, and diagrams must be updated in lockstep.
+---
+
+# Pipeline Step Documentation Sync
+
+## Context
+
+The ingestion pipeline is the spine of this project. Steps are declared in
+`episodes/models.py` (`PIPELINE_STEPS`) and orchestrated by
+`episodes/workflows.py`. Two human-facing surfaces document it:
+
+- `README.md` — short summary table of the steps
+- `doc/README.md` — detailed per-step descriptions
+
+There are also Excalidraw diagrams under `doc/` that may visualise the flow.
+
+When the pipeline changes (a step is added, removed, renamed, reordered,
+re-scoped, or its terminal status semantics change) those surfaces drift
+silently — there is no test that catches it. AGENTS.md explicitly calls this
+out: "Keep in sync: When adding, removing, or changing a pipeline step,
+update the summary table in README.md and the detailed step descriptions in
+doc/README.md."
+
+## What to Check
+
+### 1. PIPELINE_STEPS edits must propagate to docs
+
+If the diff touches `episodes/models.py` `PIPELINE_STEPS`, or adds/removes
+a `@DBOS.step()` in `episodes/workflows.py`, both of these must also change:
+
+- The pipeline summary table in `README.md`
+- The detailed step section in `doc/README.md`
+
+**BAD** — PR adds a new `verify` step between `embed` and `ready` in
+`episodes/models.py` and `episodes/workflows.py`, but `README.md` and
+`doc/README.md` still list 10 steps without it.
+
+**GOOD** — same code change, plus README/doc updates that include `verify`,
+its trigger, its terminal statuses, and any new error states.
+
+### 2. Status name renames must propagate
+
+`Episode.status` values (e.g. `queued`, `fetching_details`, `ready`,
+`failed`) appear in admin views, templates, and prose docs. If a status is
+renamed in `models.py`, search for it across `episodes/`, `chat/`,
+`templates/`, and `doc/` and confirm all references update.
+
+### 3. Diagrams must be flagged when stale
+
+If pipeline structure changes, check whether any `.excalidraw` files in
+`doc/` depict the pipeline. Diagrams cannot be auto-updated. Either:
+
+- The PR also updates the diagram (PNG/SVG export plus the source file), OR
+- The PR description explicitly notes the diagram is now stale and tracks
+  follow-up.
+
+Silently-stale diagrams are a fail.
+
+### 4. DBOS queue / concurrency changes deserve a doc note
+
+Changes to `RAGTIME_EPISODE_CONCURRENCY`, the `episode_pipeline` queue
+config, or the deterministic workflow ID scheme (`episode-<id>-run-<n>`)
+must be reflected in the "Pipeline parallelism" paragraph of
+`AGENTS.md`/`CLAUDE.md` and the relevant section of `doc/README.md`.
+
+## Key Files
+
+- `episodes/models.py` — `PIPELINE_STEPS`, `Episode.status` choices
+- `episodes/workflows.py` — DBOS workflow + steps
+- `README.md` — summary table
+- `doc/README.md` — detailed step descriptions
+- `doc/*.excalidraw` — diagrams (manual update only)
+- `AGENTS.md` / `CLAUDE.md` — architecture summary
+
+## Exclusions
+
+- Refactors that preserve step names, order, count, and terminal statuses
+  (e.g. renaming an internal helper, extracting a sub-function inside a step).
+- Pure bug fixes inside a step that don't change its contract.
+- Tests-only PRs.

--- a/.continue/checks/qdrant-payload-slim.md
+++ b/.continue/checks/qdrant-payload-slim.md
@@ -1,0 +1,95 @@
+---
+name: Slim Qdrant Payload Discipline
+description: Qdrant chunk points must carry only filter fields. All display data is hydrated from Postgres at search time.
+---
+
+# Slim Qdrant Payload Discipline
+
+## Context
+
+The repo has one source of truth per piece of data, and it is Postgres for
+everything except vectors. Qdrant chunk points carry **only** the fields
+needed for server-side filtering:
+
+- `chunk_id`
+- `episode_id`
+- `language`
+- `entity_ids`
+
+Everything else — episode title, episode URLs, chunk text, entity names,
+MusicBrainz IDs, Wikidata IDs — is hydrated from Postgres in
+`vector_store.search_chunks()` via a single keyed query.
+
+This is deliberate. It means title edits, MBID resolutions, and Wikidata
+enrichment flow into Scott's results immediately, without re-embedding
+or `client.set_payload(...)` calls. Adding a "convenience" field to the
+Qdrant payload silently re-introduces the dual-source-of-truth bug this
+design exists to prevent.
+
+## What to Check
+
+### 1. No new fields on PointStruct.payload
+
+Look for changes that add keys to the dict passed as `payload=` when
+building `qm.PointStruct(...)` in `episodes/vector_store.py` (or
+anywhere chunks are upserted into Qdrant). The allowed set is exactly:
+`chunk_id`, `episode_id`, `language`, `entity_ids`.
+
+**BAD**
+
+```python
+qm.PointStruct(
+    id=p.id,
+    vector=p.vector,
+    payload={
+        "chunk_id": p.chunk_id,
+        "episode_id": p.episode_id,
+        "language": p.language,
+        "entity_ids": p.entity_ids,
+        "episode_title": p.episode_title,  # NO — hydrate from Postgres
+    },
+)
+```
+
+**GOOD** — keep the payload to the four allowed keys; surface the title
+in `search_chunks()` by joining the returned `episode_id` against
+`Episode.objects.in_bulk(...)`.
+
+### 2. No `client.set_payload` / `client.update_vectors` mutations
+
+Anything that calls `set_payload`, `overwrite_payload`, `update_vectors`,
+or otherwise mutates Qdrant points after upsert is a smell. The only
+legitimate mutation paths are: re-embedding (full point replace) and
+deletes. Flag and ask why.
+
+### 3. New display data must be hydrated, not stored
+
+If a PR adds a new piece of data Scott needs to show users (e.g.
+episode publication date, host name), the implementation should:
+
+- Add/use the column on the Postgres model.
+- Extend the keyed lookup in `vector_store.search_chunks()` to fetch it.
+- **Not** add it to the Qdrant payload.
+
+### 4. New filter fields are the only legitimate payload additions
+
+If a new field genuinely needs to drive a Qdrant `Filter` (server-side
+narrowing of results before scoring), then adding it to the payload is
+correct. In that case, confirm:
+
+- A `create_payload_index` call covers the new field, or there's a clear
+  reason it's not indexed.
+- The field is small and stable (IDs, enums, language codes) — not free
+  text, not anything that changes via user edits.
+
+## Key Files
+
+- `episodes/vector_store.py` — upserts and `search_chunks()` hydration
+- `episodes/embedder.py` (if present) — anywhere `PointStruct` is built
+- `episodes/models.py` — Postgres source of truth for hydrated fields
+
+## Exclusions
+
+- Migrations that backfill existing points to remove a field (cleanup is
+  fine, even encouraged).
+- Tests that build fake `PointStruct`s for assertion purposes.


### PR DESCRIPTION
Closes #117.

## Summary

- Adds nine [Continue.dev](https://continue.dev/walkthrough) checks under `.continue/checks/`, one Markdown file each, with frontmatter + Context + What to Check (with GOOD/BAD examples) + Key Files + Exclusions.
- Every check targets a documented invariant from `AGENTS.md`/`CLAUDE.md` or a past incident (e.g. `entity-creation-race-safety` references the resolver deadlock fixed in `4b69d9e`). Nothing a linter or type checker already covers.
- No runtime code changes; this is reviewer tooling only.

## Checks added

| File | What it catches |
|---|---|
| `pipeline-step-sync.md` | `PIPELINE_STEPS` / DBOS step changes that don't update `README.md`, `doc/README.md`, or stale Excalidraw diagrams |
| `env-var-sync.md` | New/renamed/removed `RAGTIME_*` vars not reflected in `.env.sample` and `configure.py` |
| `feature-pr-docs.md` | Feature PRs missing the plan + feature doc + both session transcripts + changelog entry, or with malformed metadata |
| `qdrant-payload-slim.md` | New keys added to Qdrant `PointStruct.payload`, or `set_payload` mutations re-introducing the dual-source-of-truth bug |
| `entity-creation-race-safety.md` | Bare `Entity.objects.create`, unsorted advisory locks, paths that bypass `_get_or_create_entity` |
| `comment-discipline.md` | WHAT-comments, task/PR/caller references, tombstones — while preserving load-bearing WHY comments |
| `gh-api-shell-escaping.md` | `gh api` bodies with backticks not in heredocs, the bogus `/replies` endpoint, review-vs-issue endpoint mix-ups |
| `asgi-wsgi-scott.md` | Scott PRs whose test plan only used `runserver` (WSGI silently 404s `/chat/agent/`), sync-only middleware blocking the event loop |
| `branching-and-pr-strategy.md` | PRs from `main`, branches not rebased, merge commits inside the feature branch, squash-shaped commit messages |

## On the doc bundle

Per `feature-pr-docs.md` (the check this very PR adds), feature PRs should ship a plan, feature doc, and both session transcripts. I deliberately did **not** generate those for this PR because:

1. There was no separate planning session — the design is the walkthrough's format applied to invariants already documented in `AGENTS.md`/`CLAUDE.md`.
2. This PR adds zero runtime behaviour; it's tooling/config closer to a chore than a feature.

Happy to add a feature doc + session transcript in a follow-up commit if you'd rather treat tooling-of-this-size as a feature. Worth deciding for the rule itself.

## Test plan

- [x] `cat .continue/checks/*.md` reads cleanly; frontmatter parses; markdown renders.
- [x] (Manual) point Continue.dev at this branch on a sample PR and confirm at least one check fires sensibly.
- [x] No CI changes expected — Continue.dev integration is out of scope (see #117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)