### PR TITLE
Surface AI Checks failures as a sticky PR comment

### DIFF
--- a/.github/scripts/aggregate_ai_checks.py
+++ b/.github/scripts/aggregate_ai_checks.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Aggregate per-rule AI Check verdicts into a sticky PR comment body.
+
+Reads all `*.json` files under a directory (each produced by `run_ai_check.py
+--output`) and writes:
+
+- A Markdown body to `--body-out` (only meaningful when there is at least
+  one FAIL).
+- The literal string `true` or `false` to `--has-fail-out`, so the workflow
+  can branch on whether to upsert or delete the sticky comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VERDICT_ORDER = {"fail": 0, "skip": 1, "pass": 2}
+
+
+def load_results(results_dir: Path) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for p in sorted(results_dir.rglob("*.json")):
+        try:
+            items.append(json.loads(p.read_text()))
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"warning: skipping {p}: {e}", file=sys.stderr)
+    items.sort(key=lambda r: (VERDICT_ORDER.get(r.get("verdict", "pass"), 9), r.get("name", "")))
+    return items
+
+
+def render_body(results: list[dict[str, Any]]) -> str:
+    fails = [r for r in results if r.get("verdict") == "fail"]
+    passes = [r for r in results if r.get("verdict") == "pass"]
+    skips = [r for r in results if r.get("verdict") == "skip"]
+
+    lines: list[str] = []
+    lines.append("## AI Checks summary")
+    lines.append("")
+    lines.append(
+        f"❌ **{len(fails)} fail** · ✅ {len(passes)} pass · ⏭️ {len(skips)} skip"
+    )
+    lines.append("")
+
+    for r in fails:
+        lines.append(f"### ❌ {r.get('name', '(unnamed)')}")
+        lines.append("")
+        desc = (r.get("description") or "").strip()
+        if desc:
+            lines.append(f"> {desc}")
+            lines.append("")
+        summary = r.get("summary") or "_No summary._"
+        lines.append(f"**{summary}**")
+        lines.append("")
+        details = (r.get("details") or "").strip()
+        if details:
+            lines.append("<details><summary>Details</summary>")
+            lines.append("")
+            lines.append(details)
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+    if passes or skips:
+        if fails:
+            lines.append("---")
+            lines.append("")
+        lines.append(f"### Other checks ({len(passes)} passing · {len(skips)} skipped)")
+        lines.append("")
+        lines.append("<details><summary>Show details</summary>")
+        lines.append("")
+        for r in passes:
+            lines.append(f"- ✅ **{r.get('name', '(unnamed)')}** — {r.get('summary', '')}")
+        for r in skips:
+            lines.append(f"- ⏭️ **{r.get('name', '(unnamed)')}** — {r.get('summary', '')}")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--results-dir", type=Path, required=True)
+    ap.add_argument("--body-out", type=Path, required=True)
+    ap.add_argument("--has-fail-out", type=Path, required=True)
+    args = ap.parse_args()
+
+    results = load_results(args.results_dir)
+    has_fail = any(r.get("verdict") == "fail" for r in results)
+
+    args.has_fail_out.write_text("true" if has_fail else "false")
+
+    if has_fail:
+        args.body_out.write_text(render_body(results))
+    else:
+        args.body_out.write_text("")
+
+    print(f"results: {len(results)}, has_fail: {has_fail}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/run_ai_check.py
+++ b/.github/scripts/run_ai_check.py
@@ -213,6 +213,17 @@ def write_step_summary(check_name: str, result: dict[str, str]) -> None:
     Path(summary_path).write_text(md)
 
 
+def write_output_json(path: Path, name: str, description: str, result: dict[str, str]) -> None:
+    payload = {
+        "name": name,
+        "description": description,
+        "verdict": result["verdict"],
+        "summary": result.get("summary", ""),
+        "details": result.get("details", ""),
+    }
+    path.write_text(json.dumps(payload, indent=2))
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("check", type=Path, help="Path to a .ai-checks/*.md rule file")
@@ -226,24 +237,31 @@ def main() -> int:
         default=os.environ.get("AI_CHECK_MODEL", DEFAULT_MODEL),
         help=f"LiteLLM model string, e.g. openai/gpt-4o-mini (default: {DEFAULT_MODEL})",
     )
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=Path(os.environ["AI_CHECK_OUTPUT"]) if os.environ.get("AI_CHECK_OUTPUT") else None,
+        help="Optional path to write the verdict as JSON (also reads $AI_CHECK_OUTPUT).",
+    )
     args = ap.parse_args()
 
     fm, _ = parse_check(args.check)
     name = fm.get("name", args.check.stem)
+    description = fm.get("description", "")
 
     try:
         result = evaluate(args.check, args.base, args.model)
     except ConfigError as e:
         print(f"[CONFIG ERROR] {name}", file=sys.stderr)
         print(str(e), file=sys.stderr)
-        write_step_summary(
-            name,
-            {
-                "verdict": "fail",
-                "summary": "Setup error — see job log.",
-                "details": str(e),
-            },
-        )
+        result = {
+            "verdict": "fail",
+            "summary": "Setup error — see job log.",
+            "details": str(e),
+        }
+        write_step_summary(name, result)
+        if args.output:
+            write_output_json(args.output, name, description, result)
         print(f"::error title=AI check setup error ({name})::{e}")
         return 2
 
@@ -255,6 +273,8 @@ def main() -> int:
         print(result["details"])
 
     write_step_summary(name, result)
+    if args.output:
+        write_output_json(args.output, name, description, result)
     return 1 if result["verdict"] == "fail" else 0
 
 

--- a/.github/workflows/ai-checks.yml
+++ b/.github/workflows/ai-checks.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   list:
@@ -38,6 +38,11 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
+      - name: Sanitize matrix name for artifact
+        id: slug
+        run: |
+          slug=$(printf '%s' "${{ matrix.name }}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
       - name: Run check
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -45,6 +50,50 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
           AI_CHECK_MODEL: ${{ vars.AI_CHECK_MODEL || 'openai/gpt-4o-mini' }}
+          AI_CHECK_OUTPUT: ${{ runner.temp }}/ai-check-result.json
         run: |
+          mkdir -p "${{ runner.temp }}"
           git fetch --no-tags --depth=200 origin "${{ github.event.pull_request.base.ref }}"
           uv run --with litellm python .github/scripts/run_ai_check.py "${{ matrix.path }}"
+      - name: Upload verdict artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-check-result-${{ steps.slug.outputs.slug }}
+          path: ${{ runner.temp }}/ai-check-result.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  aggregate:
+    needs: check
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download verdict artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ai-check-results
+          pattern: ai-check-result-*
+          merge-multiple: false
+      - name: Render sticky comment body
+        id: render
+        run: |
+          mkdir -p ai-check-results
+          python .github/scripts/aggregate_ai_checks.py \
+            --results-dir ai-check-results \
+            --body-out comment-body.md \
+            --has-fail-out has-fail.txt
+          echo "has_fail=$(cat has-fail.txt)" >> "$GITHUB_OUTPUT"
+      - name: Upsert sticky comment (failures present)
+        if: steps.render.outputs.has_fail == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: ai-checks-summary
+          path: comment-body.md
+      - name: Delete sticky comment (all green)
+        if: steps.render.outputs.has_fail == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: ai-checks-summary
+          delete: true


### PR DESCRIPTION
## Summary

- Each AI Checks matrix job now writes its verdict (pass/fail/skip + summary + details) to a JSON artifact via the new `--output` flag on `run_ai_check.py`.
- A new `aggregate` job downloads all per-rule artifacts, renders a single Markdown summary, and either upserts or deletes a sticky PR comment using [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment) keyed on the `ai-checks-summary` header.
- Each FAIL section in the comment includes the rule's frontmatter `description:` as a blockquote, so reviewers can interpret the violation in the context of what the rule is checking for.
- Passing and skipped rules are grouped under a top-level `### Other checks (N passing · M skipped)` heading separated by a horizontal rule, so the boundary between the failure region and the rest of the suite is unambiguous.
- Bumps the workflow's `pull-requests` permission to `write`.

Behavior on re-runs:

| Previous state | New run result | What happens |
|---|---|---|
| No comment | All pass / skip | Nothing |
| No comment | Any fail | Comment is created |
| Comment exists | Still has fails | Comment updated in place |
| Comment exists | Flipped to all-pass | Comment is deleted |

The per-job ✓/✗ check icons remain the source of truth for required-check gating; the sticky comment exists only when there's something to read.

Closes #132

## Test plan

- [x] (in-PR) Plant a `comment-discipline` violation; confirm sticky comment appears with FAIL details.
- [x] (in-PR) Push a follow-up commit removing the violation; confirm sticky comment is deleted.
- [x] (in-PR) Plant violations across multiple rules; confirm multi-FAIL rendering with separate sections, rule descriptions, and clearly separated "Other checks" block.
- [x] Force-push to drop the test commits before merge.