### PR TITLE
Recognize agent-orchestrated sessions in transcript policy

### DIFF
--- a/.ai-checks/feature-pr-docs.md
+++ b/.ai-checks/feature-pr-docs.md
@@ -108,11 +108,22 @@ interactions up to and including PR review feedback and follow-up
 changes. If the PR has had review rounds, confirm those rounds appear
 in the transcript — not just the initial implementation.
 
-### 6. User messages are verbatim
+### 6. User / parent-agent messages are verbatim
 
-Spot-check the transcript: user sections should read like real,
+Spot-check the transcript: `### User` sections should read like real,
 unedited messages (typos, casual phrasing, context). If they read like
 clean prose summaries, they have been paraphrased and need fixing.
+
+AGENTS.md also recognizes **agent-orchestrated sessions** (parallel
+implementation agents launched from a parent Claude Code session, e.g.
+under Conductor). In that case the transcript may use
+`### Parent agent (orchestrator)` headings *instead of* `### User`,
+provided the parent-agent's launching prompt is reproduced verbatim
+(same verbatim rule). The transcript must explicitly declare the
+session as agent-orchestrated at the top of `## Detailed conversation`,
+not silently substitute the heading. Either form (real verbatim user
+messages, or honest agent-orchestrated declaration with verbatim parent
+prompt) satisfies this check; summarized/paraphrased content does not.
 
 ## Key Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,19 @@ Feature documentation lives in `doc/features/`, one Markdown file per feature or
 
 Save the implementation session transcript to `doc/sessions/`, with a `YYYY-MM-DD-` date prefix and a filename ending in `-implementation-session.md` (e.g., `2026-03-15-my-feature-implementation-session.md`). Same format as the planning session (session ID, summary, verbatim conversation with reasoning steps). The implementation transcript must include all interactions up to and including PR review feedback and any follow-up changes made after the PR is created.
 
+### Agent-orchestrated sessions
+
+When a session is launched by a parent agent (e.g., a parallel implementation agent spawned from a parent Claude Code session in Conductor) and has no direct user-to-implementation-agent messages, the transcript must declare this honestly rather than fabricate `### User` content.
+
+Use `### Parent agent (orchestrator)` headings *instead of* `### User` for such sections, and reproduce the parent-agent's launching prompt verbatim — same verbatim rule as for real user messages. This applies to either or both transcripts:
+
+- **Planning transcripts** rarely fall into this case — planning sessions almost always have real user messages.
+- **Implementation transcripts** frequently fall into this case under Conductor's parallel-launch workflow, where the user authorizes the parallel session in the parent conversation and the implementation agent runs from an agent-written brief.
+
+Add a one-paragraph note at the top of the `## Detailed conversation` section explicitly identifying the session as agent-orchestrated and pointing at the parent conversation if accessible. Do not fabricate user messages, and do not silently summarize the parent prompt.
+
+If the entire feature has no direct user messages anywhere (rare — usually the user at least authorized the work), the planning transcript may be omitted; the implementation transcript with the agent-orchestrated declaration is sufficient. Document the choice in the feature doc.
+
 Every doc file must start with a `# Title` on the very first line. Metadata lines go immediately after the title, before any `## Section`: first `**Date:** YYYY-MM-DD` (all doc types), then `**Session ID:**` (session transcripts only). Never place metadata above the title. Separate each metadata line with a blank line so they render as distinct paragraphs in Markdown (e.g., a blank line between `**Date:**` and `**Session ID:**`).
 
 Keep prose concise. Prefer tables and lists over long paragraphs. Use code blocks for CLI commands and signal-flow diagrams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2026-05-04
+
+### Changed
+
+- AGENTS.md and the Feature PR Documentation Bundle AI check now recognize **agent-orchestrated sessions**. When a parallel implementation agent is launched from a parent Claude Code session (e.g. under Conductor) and has no direct user-to-implementation-agent messages, the transcript may use `### Parent agent (orchestrator)` headings *instead of* `### User`, provided the parent-agent's launching prompt is reproduced verbatim. The transcript must declare the session as agent-orchestrated at the top of `## Detailed conversation`. Same verbatim rule applies — summarized parent prompts are still rejected. This is a policy clarification only; no code changes.
+
 ## 2026-05-01
 
 ### Added


### PR DESCRIPTION
## Summary

AGENTS.md's transcript policy assumed the human-with-Claude workflow where every session has real `### User` messages. Conductor's parallel-launch model breaks that assumption: the implementation session has no direct user, only an agent-orchestrated launching prompt.

This PR adds a new **"Agent-orchestrated sessions"** subsection to AGENTS.md and a matching note to the Feature PR Documentation Bundle AI check.

The new convention:
- Use `### Parent agent (orchestrator)` headings *instead of* `### User`
- Reproduce the parent-agent prompt verbatim (same verbatim rule)
- Declare the session as agent-orchestrated at the top of `## Detailed conversation`
- Summarized parent prompts are still rejected

This eliminates a recurring false-negative on the docs check that was raised on PRs #129, #130, #131, and #133 — where the implementation agents had no real user to quote and the existing policy left them no honest path forward.

## Classification

Doc-only / policy clarification PR. Per the AI Checks rule's exclusions, this does not need the full feature documentation bundle (plan + feature doc + both transcripts). CHANGELOG entry only.

## Test plan

- [x] AI Checks workflow on this PR runs successfully and the Feature PR Documentation Bundle check does not fail (it's a doc-only PR; the rule's exclusions list covers this case)
- [ ] On the next PR that uses an agent-orchestrated implementation session and follows the new convention, the docs check should pass instead of failing on missing verbatim user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)